### PR TITLE
Fix: Correct typos and format. Add separate lines.

### DIFF
--- a/cs/libred.adoc
+++ b/cs/libred.adoc
@@ -346,7 +346,7 @@ Vrací 'UTF-8_string_buffer_pointer' z hodnoty `string!` v Redu. Jiná kódován
 long redTypeOf(red_value value)
 ----
 
-Vrací ID typu z hodnoty v Red. Hodnoty ID typů jsou definovány ve výčtu `RedType`. Viz link:libred.adoc#_datatypes_definition[Datatypes] section.
+Vrací ID typu z hodnoty v Red. Hodnoty ID typů jsou definovány ve výčtu `RedType`. Viz link:libred.adoc#datatypes-definition[Datatypes] section.
 
 === Volání akce v Redu
 
@@ -588,6 +588,7 @@ Closes the log file opened with `redOpenLogFile()`.
 
 NOTE: V současné době *musí* být logovací soubor při exitu zavřen, jinak je nad ním držen zámek (lock) a to může způsobit zamrznutí nebo kolaps v některých hostitelských (např. MS Office) aplikacích.
 
+[#datatypes-definition]
 === Definice datových typů
 
 Některé funkce z libRed API se mohou odkazovat na datové typy Redu: `redTypeOf()`, `redMakeSeries()` a `redDatatype()`. Tyto typy jsou na hostitelské straně prezentovány jako výčet (`RedType`), kde typy jsou zastoupeny jmény podle následujícího schematu:

--- a/en/char.adoc
+++ b/en/char.adoc
@@ -8,9 +8,10 @@ Version: Draft 3
 `Char!` values represent a Unicode code point. They are integer numbers in the range hexadecimal 00 to hexadecimal 10FFFF. (0 to 1,114,111 in decimal.) 
 
 == Characteristics
+
 'Char!' values are 'direct', 'atomic' and 'passive'.
 
-Note: This assumes that Type Characteristics have been defined earlier in the document.
+NOTE: This assumes that Type Characteristics have been defined earlier in the document.
 
 == Creation
 
@@ -19,6 +20,7 @@ Note: This assumes that Type Characteristics have been defined earlier in the do
 === Literal syntax
 
 The basic literal formats for `char!` values is:
+
 ----
 #"<character>"
 <character> : a single Unicode codepoint (usually entered via keystrokes)
@@ -31,12 +33,14 @@ The escape character in Red is '^' - codepoint U+005E. As a result, the ^ charac
 There are three forms of escaped character literals in Red, one for numeric codepoints, another for named characters and the other for "control" characters.
 
 The codepoint form is:
+
 ----
 #"^(<codepoint>)"
 <codepoint> : a valid hexadecimal e.g. 00, ABCD, 10FFFFF
 ----
 
 The "control" characters form is:
+
 ----
 #"^<cc>"
 <cc> : A single character from the set - A-Z, [, \, ], _
@@ -67,6 +71,7 @@ The "control" characters form is:
 |===
 
 The "named" characters form is:
+
 ----
 #"^(<name>)" or #"^<symbol>" 
 <name> : a name from Named Escaped Characters table
@@ -134,6 +139,7 @@ The "named" characters form is:
 All comparators can be applied on 'char!' values: `=, ==, <>, >, <, >=, &lt;=, same?`. In addition, `min`, `max` and `sort` are supported. Comparison of `char!` values is case sensitive.
 
 *Examples*
+
 ----
 #"a" = #"A"
 == false
@@ -149,6 +155,7 @@ sort [#"c" #"b" #"d" #"a"]
 The full range of mathematical functions can be used with `char!` values. A `Math Error` is raised if the result of the arithmetic falls outside of the range 00 - 10FFFF (hexadecimal).
 
 *Examples*
+
 ----
 #"a" + 1
 == #"b"
@@ -162,6 +169,7 @@ The full range of mathematical functions can be used with `char!` values. A `Mat
 *** Stack:  
 
 ----
+
 == Other char-related functions
 
 Lowercase, Uppercase

--- a/en/date.adoc
+++ b/en/date.adoc
@@ -6,11 +6,12 @@
 
 `Date!` values represent calendar dates, relying on the Gregorian calendar. A date value can also contain optional time and timezone information. Time in dates is expressed in 24-hour format (including optional time zone information). Red's dates also have an extensive support for https://en.wikipedia.org/wiki/ISO_8601[ISO 8601] input formats.
 
-Note:
-
+[NOTE]
+====
 * `date!` uses a https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar[proleptic Gregorian calendar], extending its usage backward, beyond the year 1582. Care should be taken when trying to represent historical, pre-Gregorian dates using `date!` values.
 
 * Supported dates range from `1/Jan/-16384` to `31/Dec/16383`, wrapping around on overflowing math operations. On input, that range is reduced from `1/Jan/-9999` to `31/Dec/9999` for practical reasons.
+====
 
 == Creation
 
@@ -19,6 +20,7 @@ Note:
 === Literal syntax
 
 Many different literal formats are supported, including all Rebol date formats and most of the ISO date standard.
+
 ----
 <date>/<time>
 <date>/<time><zone>
@@ -90,14 +92,17 @@ Many different input formats for literal dates are accepted. Out of range values
 <dd>-<mon>-<yyyy>/<hour>:<min>:<sec>
 <dd>-<mon>-<yyyy>/<hour>:<min>:<sec><sign><hour>:<min15>
 ----
+
 When the time and/or zone fields are unset, they are omitted. For negative dates, the `/` separator is used instead of `-` for better readability.
 
-Notes:
-
+[NOTE]
+====
 * When a month is specified using letters, the month is expressed using its English name, and is case-insensitive.
 * When a year is specified using only 2 digits (`yy`): if it is < 50, it's interpreted as `20yy`, otherwise, it's interpreted as `19yy`.
+====
 
 Examples of valid input dates:
+
 ----
 1999-10-5
 1999/10/5
@@ -134,6 +139,7 @@ Examples of valid input dates:
 ----
 
 === Runtime creation
+
 ----
 make date! [<day> <month> <year>]
 make date! [<year> <month> <day>]
@@ -152,13 +158,15 @@ make date! [<day> <month> <year> <hour> <minute> <second> <zone>]
 <second> : integer! value
 ----
 
-Notes:
-
+[NOTE]
+====
 * Out of range argument values will result in an error. For a normalized result, use the `to` action instead of `make`.
 
 * `year` and `day` fields are interchangeable, but only for low year values. The year can be used in first position *only* if its value is >= 100 and less than the value of the third field. When that rule is not satisfied, the third field is considered the year. Negative years should always be specified in the third position.
+====
 
 *Examples*
+
 ----
 make date! [1978 2 3]
 == 3-Feb-1978
@@ -197,6 +205,7 @@ Path accessors provide a convenient way for getting and setting all `date!` valu
 === /date
 
 *Syntax*
+
 ----
 <date>/date
 <date>/date: <date2>
@@ -204,11 +213,13 @@ Path accessors provide a convenient way for getting and setting all `date!` valu
 <date>  : a word or path expression referring to a date! value
 <date2> : a date! value
 ----
+
 *Description*
 
 Gets or sets the date field of a date (excluding time and zone). Dates are returned as `date!` values.
 
 *Examples*
+
 ----
 d:  now
 == 10-Jul-2017/22:46:22-06:00
@@ -222,6 +233,7 @@ d/date: 15/09/2017
 === /year
 
 *Syntax*
+
 ----
 <date>/year
 <date>/year: <year>
@@ -229,11 +241,13 @@ d/date: 15/09/2017
 <date> : a word or path expression referring to a date! value
 <year> : an integer! value
 ----
+
 *Description*
 
 Gets or sets the year field of a date. Years are returned as integers. Out of range argument values will result in a normalized date.
 
 *Examples*
+
 ----
 d:  now
 == 10-Jul-2017/22:46:22-06:00
@@ -258,6 +272,7 @@ d
 === /month
 
 *Syntax*
+
 ----
 <date>/month
 <date>/month: <month>
@@ -265,11 +280,13 @@ d
 <date>  : a word or path expression referring to a date! value
 <month> : an integer! value
 ----
+
 *Description*
 
 Gets or sets the month field of a date. Months are returned as integers. Out of range argument values will result in a normalized date.
 
 *Examples*
+
 ----
 d: now
 == 10-Jul-2017/22:48:31-06:00
@@ -288,6 +305,7 @@ d/month
 === /day
 
 *Syntax*
+
 ----
 <date>/day
 <date>/day: <day>
@@ -295,11 +313,13 @@ d/month
 <date> : a word or path expression referring to a date! value
 <day>  : an integer! value
 ----
+
 *Description*
 
 Gets or sets the day field of a date. Days are returned as integers. Out of range argument values will result in a normalized date.
 
 *Examples*
+
 ----
  d: 1-jan-2017
 == 1-Jan-2017
@@ -316,6 +336,7 @@ d
 === /time
 
 *Syntax*
+
 ----
 <date>/time
 <date>/time: <time>
@@ -323,6 +344,7 @@ d
 <date> : a word or path expression referring to a date! value
 <time> : a time! or none! value
 ----
+
 *Description*
 
 Gets or sets the time field of a date. Times are returned as `time!` values, or `none!` value if time is not set, or has been reset (see below). Out of range argument values will result in a normalized date.
@@ -330,6 +352,7 @@ Gets or sets the time field of a date. Times are returned as `time!` values, or 
 If the time is set to a `none!` value, the time and zone fields are set to zero and will not be shown further.
 
 *Examples*
+
 ----
 d: now
 == 10-Jul-2017/23:18:54-06:00
@@ -344,6 +367,7 @@ d/time: none
 === /hour
 
 *Syntax*
+
 ----
 <date>/hour
 <date>/hour: <hour>
@@ -351,11 +375,13 @@ d/time: none
 <date> : a word or path expression referring to a date! value
 <hour> : an integer! value
 ----
+
 *Description*
 
-Gets or sets the time field of a date. Hours are returned as integer values between 0 and 23. Out of range argument values will result in a normalized date.
+Gets or sets the hour field of a date. Hours are returned as integer values between 0 and 23. Out of range argument values will result in a normalized date.
 
 *Examples*
+
 ----
 d: now
 == 10-Jul-2017/23:19:40-06:00
@@ -372,6 +398,7 @@ d
 === /minute
 
 *Syntax*
+
 ----
 <date>/minute
 <date>/minute: <minute>
@@ -379,13 +406,14 @@ d
 <date>   : a word or path expression referring to a date! value
 <minute> : an integer! value
 ----
+
 *Description*
 
 Gets or sets the minute field of a date. Minutes are returned as integer values between 0 and 59. Out of range argument values will result in a normalized date.
 
 *Examples*
-----
 
+----
 == 10-Jul-2017/23:20:25-06:00
 d/minute: 0
 == 0
@@ -400,6 +428,7 @@ d
 === /second
 
 *Syntax*
+
 ----
 <date>/second
 <date>/second: <second>
@@ -407,11 +436,13 @@ d
 <date>   : a word or path expression referring to a date! value
 <second> : an integer! or float! value
 ----
+
 *Description*
 
 Gets or sets the second field of a date. Seconds are returned as `integer!` or `float!` values between 0 and 59. Out of range argument values will result in a normalized date.
 
 *Examples*
+
 ----
 d: now
 == 10-Jul-2017/23:21:15-06:00
@@ -432,6 +463,7 @@ d
 === /zone
 
 *Syntax*
+
 ----
 <date>/zone
 <date>/zone: <zone>
@@ -439,6 +471,7 @@ d
 <date> : a word or path expression referring to a date! value
 <zone> : a time! or integer! value
 ----
+
 *Description*
 
 Gets or sets the timezone field of a date. Timezones are returned as `time!` values between -16:00 and +15:00. Setting the timezone with `/zone` will only modify that field, time is kept the same. Out of range argument values will result in a normalized date.
@@ -448,6 +481,7 @@ When the timezone is set to an `integer!` argument, the argument represents hour
 The granularity for timezone's minutes is 15, non-conforming values will be rounded to closest 15 minutes inferior multiple.
 
 *Examples*
+
 ----
 d: 1/3/2017/5:30:0
 d/zone: 8
@@ -460,13 +494,15 @@ d/zone: -4:00
 === /timezone
 
 *Syntax*
+
 ----
 <date>/timezone
-<date>/timezone: <zone>
+<date>/timezone: <timezone>
 
 <date>     : a word or path expression referring to a date! value
 <timezone> : an integer!, time! or pair! value
 ----
+
 *Description*
 
 Gets or sets the timezone field of a date. Timezones are returned as `time!` values between -16:00 and +15:00. Setting the timezone with `/timezone` will modify both the time and the zone, keeping the new time equivalent to the old one in the new zone. Out of range argument values will result in a normalized date.
@@ -476,6 +512,7 @@ When the timezone is set to an `integer!` argument, the argument represents hour
 The granularity for timezone's minutes is 15, non-conforming values will be rounded to closest 15 minutes inferior multiple.
 
 *Examples*
+
 ----
 d: 1/3/2017/5:30:0
 d/timezone: 8
@@ -485,13 +522,15 @@ d/timezone: -4:00
 == 1-Mar-2017/1:30:00-04:00
 ----
 
-Note:
-
+[NOTE]
+====
 * Setting the `/timezone` to 0 will set the time to UTC.
+====
 
 === /yearday
 
 *Syntax*
+
 ----
 <date>/yearday
 <date>/yearday: <day>
@@ -499,6 +538,7 @@ Note:
 <date>    : a word or path expression referring to a date! value
 <yearday> : an integer! value
 ----
+
 *Description*
 
 Gets the day of the year of a date, starting at 1 for January 1st. Days are returned as integers. When used for setting the day of the year, the date is recalculated to match that day. Out of range argument values will result in a normalized date.
@@ -508,6 +548,7 @@ Note:
 * a `/julian` alias for `/yearday` is also available, for compatibility with Rebol.
 
 *Examples*
+
 ----
 d: 1-jan-2017
 == 1-Jan-2017
@@ -533,6 +574,7 @@ d
 === /weekday
 
 *Syntax*
+
 ----
 <date>/weekday
 <date>/weekday: <day>
@@ -540,11 +582,13 @@ d
 <date>    : a word or path expression referring to a date! value
 <weekday> : an integer! value
 ----
+
 *Description*
 
 Gets the week day number, ranging from 1 for Monday, to 7 for Sunday. When used for setting the day of the week, the date is recalculated to match that day in the current week. Out of range argument values will result in a normalized date.
 
 *Examples*
+
 ----
 d: now
 == 10-Jul-2017/23:25:35-06:00
@@ -568,6 +612,7 @@ d
 === /week
 
 *Syntax*
+
 ----
 <date>/week
 <date>/week: <day>
@@ -575,15 +620,18 @@ d
 <date> : a word or path expression referring to a date! value
 <week> : an integer! value
 ----
+
 *Description*
 
 Gets the week number using a casual week definition (week starts on Sunday, first week starts on January 1st), ranging from 1 for first week of the year, to 53. When used for setting the week number, the date is recalculated to match the first day of that week (a Sunday). Out of range argument values will result in a normalized date.
 
-Note:
-
+[NOTE]
+====
 * The casual week definition allows first and last weeks of the year to be partial weeks, ranging from 1 day to 7 days. For accurate week calculations across years, use the `/isoweek` accessor.
+====
 
 *Examples*
+
 ----
 d: now
 == 10-Jul-2017/23:28:07-06:00
@@ -610,6 +658,7 @@ d
 === /isoweek
 
 *Syntax*
+
 ----
 <date>/isoweek
 <date>/isoweek: <day>
@@ -617,6 +666,7 @@ d
 <date>    : a word or path expression referring to a date! value
 <isoweek> : an integer! value
 ----
+
 *Description*
 
 Gets the week number using the https://en.wikipedia.org/wiki/ISO_week_date[ISO 8601] week definition, ranging from 1 for first week of the year, to 52 (or 53 for some years). When used for setting the week number, the date is recalculated to match the first day of that week (a Monday). Out of range argument values will result in a normalized date.
@@ -678,6 +728,7 @@ Such ordinal accessor can be used both for getting or setting fields. The follow
 It is possible to access date fields without using a path, which can be more convenient in some cases. `pick` can be used for that on dates.
 
 *Syntax*
+
 ----
 pick <date> <field>
 
@@ -688,6 +739,7 @@ pick <date> <field>
 An integer argument represents the ordinal accessor for dates. See "Ordinal accessors" table above.
 
 *Examples*
+
 ----
 d: now
 == 10-Jul-2017/23:35:01-06:00
@@ -716,6 +768,7 @@ repeat i 14 [print [pad i 4 pad names/:i 10 pick d i]]
 Dates can be converted from/to https://en.wikipedia.org/wiki/Unix_time[Unix epoch time] using `to` action.
 
 *Syntax*
+
 ----
 to-integer <date>
 to-date <epoch>
@@ -725,6 +778,7 @@ to-date <epoch>
 ----
 
 Epoch time are expressed in UTC. If the argument date is not in UTC, it will be converted internally before converting to epoch time.
+
 ----
 d: 8-Jul-2017/17:49:27+08:00
 to-integer d
@@ -742,11 +796,13 @@ Note that epoch time is not defined beyond the year 2038.
 === Block to date
 
 *Syntax*
+
 ----
 to date! <spec>
 
 <spec> : a block of values for date fields
 ----
+
 The argument block will be converted to a `date!` value according to the same syntax as for `make` (see 2.2 <<runtime-creation>>). Out of range argument values will result in a normalized date. For a strict conversion from a block, that will error out instead of normalizing, use `make`.
 
 == Comparisons
@@ -754,6 +810,7 @@ The argument block will be converted to a `date!` value according to the same sy
 All comparators can be applied on dates: `=, ==, <>, >, <, >=, &lt;=, same?`. In addition, `min`, `max` and `sort` are also supported.
 
 *Examples*
+
 ----
 3-Jul-2017/9:41:40+2:00 = 3-Jul-2017/5:41:40-2:00
 == true
@@ -782,6 +839,7 @@ Supported math operations on dates include:
 * using the `difference` function on two date values: result is the signed difference, as a `time!` value, between those two dates.
 
 *Examples*
+
 ----
 20-Feb-1980 + 50
 == 10-Apr-1980
@@ -829,6 +887,7 @@ The `now` function returns the operating system's current date and time (includi
 * `/precise`: get the time with higher precision (1/60th of a second on Windows, micro-seconds on Unix)
 
 *Examples*
+
 ----
 now
 == 8-Jul-2017/18:32:25+08:00
@@ -860,16 +919,19 @@ now/utc
 === Random
 
 *Syntax*
+
 ----
 random <date>
 
 <date> : a date! value
 ----
+
 *Description*
 
 Returns a randomized date using the argument date as upper limit. If the argument date has no time/timezone component, the resulting date won't have it either.
 
 *Examples*
+
 ----
 random 09/07/2017
 == 18-May-1972

--- a/en/draw.adoc
+++ b/en/draw.adoc
@@ -290,7 +290,7 @@ pen diamond <color1> <offset> ... <colorN> <offset> <upper> <lower> <focal> <spr
 
 Sets a diamond-shaped gradient to be used for drawing operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
 
-The diamond gradient will be painted from focal point to the edge of a rectangle defined by upper and lower. The start color will be painted in focal point and the end color will be painted in the edge of the circle.
+The diamond gradient will be painted from focal point to the edge of a rectangle defined by upper and lower. The start color will be painted in focal point and the end color will be painted in the edge of the diamond.
 
 ==== Pattern pen
 
@@ -408,7 +408,7 @@ fill-pen diamond <color1> <offset> ... <colorN> <offset> <upper> <lower> <focal>
 
 Sets a diamond-shaped gradient to be used for filling operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
 
-The diamond gradient will be painted from focal point to the edge of a rectangle defined by upper and lower. The start color will be painted in focal point and the end color will be painted in the edge of the circle.
+The diamond gradient will be painted from focal point to the edge of a rectangle defined by upper and lower. The start color will be painted in focal point and the end color will be painted in the edge of the diamond.
 
 ==== Pattern fill
 
@@ -778,7 +778,7 @@ Draws a line between two points. If more points are specified, additional lines 
 
 <end>      : arc's end point (pair!).
 <radius-x> : radius of the circle along x axis (integer! float!).
-<radius-y> : x coordinate of radius of the circle (integer! float!).
+<radius-y> : radius of the circle along y axis (integer! float!).
 <angle>    : angle between the starting and ending points of the arc in degrees (integer! float!).
 sweep      : (optional) draw the arc in the positive angle direction.
 large      : (optional) produces an inflated arc (goes with 'sweep option).
@@ -844,7 +844,7 @@ Draws a quadratic Bezier curve from a sequence of points, starting from the curr
 
 Draws a smooth quadratic Bezier curve from the current pen position to the specified point.
 
-NOTE: See See: http://www.w3.org/TR/SVG11/paths.html
+NOTE: See: http://www.w3.org/TR/SVG11/paths.html
 
 === Hline
 

--- a/en/draw.adoc
+++ b/en/draw.adoc
@@ -34,6 +34,7 @@ line <point> <point> ...
 
 <point> : coordinates of a point (pair!).
 ----
+
 *Description*
 
 Draws a line between two points. If more points are specified, additional lines are drawn, connecting each point in the provided order.
@@ -41,11 +42,13 @@ Draws a line between two points. If more points are specified, additional lines 
 === Triangle 
 
 *Syntax*
+
 ----
 triangle <point> <point> <point>
 
 <point> : coordinates of a vertex of the triangle (pair!).
 ----
+
 NOTE: A vertex is the point at which two lines meet. They are points where edges join.
 
 *Description*
@@ -55,6 +58,7 @@ Draws a triangle with edges between the supplied vertices.
 === Box 
 
 *Syntax*
+
 ----
 box <top-left> <bottom-right>
 box <top-left> <bottom-right> <corner>
@@ -63,6 +67,7 @@ box <top-left> <bottom-right> <corner>
 <bottom-right> : coordinates of the bottom-right of the box (pair!).
 <corner>       : (optional) radius of the arc used to draw a round corner (integer!).
 ----
+
 *Description*
 
 Draws a box using the top-left (first argument) and bottom-right (second argument) vertices. An optional radius can be provided for making round corners.
@@ -70,11 +75,13 @@ Draws a box using the top-left (first argument) and bottom-right (second argumen
 === Polygon 
 
 *Syntax*
+
 ----
 polygon <point> <point> ...
 
 <point> : coordinates of a vertex (pair!).
 ----
+
 *Description*
 
 Draws a polygon using the provided vertices. The last point does not need to be the starting point, an extra line will be drawn anyway to close the polygon. Minimal number of points to be provided is 3.
@@ -82,6 +89,7 @@ Draws a polygon using the provided vertices. The last point does not need to be 
 === Circle
  
 *Syntax*
+
 ----
 circle <center> <radius>
 circle <center> <radius-x> <radius-y>
@@ -91,6 +99,7 @@ circle <center> <radius-x> <radius-y>
 <radius-x> : (ellipse mode) radius of the circle along X axis (integer! float!).
 <radius-y> : (ellipse mode) radius of the circle along Y axis (integer! float!).
 ----
+
 *Description*
 
 Draws a circle from the provided center and radius values. The circle can be distorted to form an ellipse by adding an optional integer indicating the radius along Y axis (the other radius argument then becomes the radius along X).
@@ -98,12 +107,14 @@ Draws a circle from the provided center and radius values. The circle can be dis
 === Ellipse 
 
 *Syntax*
+
 ----
 ellipse <top-left> <size>
 
 <top-left> : coordinates of the ellipse's bounding box top-left point (pair!).
 <size>     : size of the bounding box (pair!).
 ----
+
 *Description*
 
 Draws an ellipse from the specified bounding box. The `size` argument represents the X and Y diameters of the ellipse.
@@ -113,6 +124,7 @@ NOTE: `ellipse` provide a more compact and box-oriented way to specify a circle/
 === Arc 
 
 *Syntax*
+
 ----
 arc <center> <radius> <begin> <sweep>
 arc <center> <radius> <begin> <sweep> closed
@@ -122,6 +134,7 @@ arc <center> <radius> <begin> <sweep> closed
 <begin>  : starting angle in degrees (integer!).
 <sweep>  : angle between the starting and ending points of the arc in degrees (integer!).
 ----
+
 *Description*
 
 Draws the arc of a circle from the provided center and radius values. The arc is defined by two angles values. An optional `closed` keyword can be used to draw a closed arc using two lines coming from the center point.
@@ -129,6 +142,7 @@ Draws the arc of a circle from the provided center and radius values. The arc is
 === Curve 
 
 *Syntax*
+
 ----
 curve <end-A> <control-A> <end-B>
 curve <end-A> <control-A> <control-B> <end-B>
@@ -138,6 +152,7 @@ curve <end-A> <control-A> <control-B> <end-B>
 <control-B> : control point B (pair!).
 <end-B>     : end point B (pair!).
 ----
+
 *Description*
 
 Draws a Bezier curve from 3 or 4 points:
@@ -150,12 +165,14 @@ Four points allow more complex curves to be created.
 === Spline 
 
 *Syntax*
+
 ----
 spline <point> <point> ...
 spline <point> <point> ... closed
 
 <point> : a control point (pair!).
 ----
+
 *Description*
 
 Draws a B-Spline curve from a sequence of points. At least 3 points are required to produce a spline. The optional `closed` keyword will draw an extra segment from the end point to the start point, in order to close the spline.
@@ -165,6 +182,7 @@ NOTE: 2 points are accepted, but they will produce only a straight line.
 === Image 
 
 *Syntax*
+
 ----
 image <image>
 image <image> <top-left>
@@ -183,24 +201,28 @@ image <image> <top-left> <top-right> <bottom-left> <bottom-right> <color> crop <
 <offset>       : (optional) position for starting cropping (pair!).
 <size>         : (optional) size of cropping (pair!).
 ----
+
 *Description*
 
 Paints an image using the provided information for position and width. If the image has no positioning information provided, then the image is painted at 0x0 coordinates. A color value can be optionally provided, it will be used for transparency. 
 
-NOTE:
-
+[NOTE]
+====
 * Four points mode is not yet implemented. It will allow to stretch the image using 4 arbitrary-positioned edges.
 * `border` optional mode is not yet implemented.
+====
 
 === Text 
 
 *Syntax*
+
 ----
 text <position> <string>
 
 <position> : coordinates where the string is printed (pair!).
 <string>   : text to print (string!).
 ----
+
 *Description*
 
 Prints a text string at the provided coordinates using the current font. 
@@ -210,11 +232,13 @@ NOTE: If no font is selected or if the font color is set to `none`, then the pen
 === Font 
 
 *Syntax*
+
 ----
 font <font>
 
 <font> : new font object to use (object! word!).
 ----
+
 *Description*
 
 Selects the font to be used for text printing. The font object is a clone of `font!`.
@@ -226,11 +250,13 @@ This command defines the outlines drawing mode for other commands. Many differen
 ==== Color pen
 
 *Syntax*
+
 ----
 pen <color>
 
 <color> : new color to use for drawing (tuple! word!).
 ----
+
 *Description*
 
 Selects the color to be used for drawing operations. All shapes will be drawn by the selected color until the pen is set to `off`.
@@ -238,6 +264,7 @@ Selects the color to be used for drawing operations. All shapes will be drawn by
 ==== Linear gradient pen
 
 *Syntax*
+
 ----
 pen linear <color1> <offset> ... <colorN> <offset> <start> <end> <spread>
 
@@ -247,6 +274,7 @@ pen linear <color1> <offset> ... <colorN> <offset> <start> <end> <spread>
 <end>      : (optional unless <start>) ending point (pair!).
 <spread>   : (optional) spread method (word!).
 ----
+
 *Description*
 
 Sets a linear gradient to be used for drawing operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
@@ -257,6 +285,7 @@ the gradient will be paint along a horizontal line inside the shape currently dr
 ==== Radial gradient pen
 
 *Syntax*
+
 ----
 pen radial <color1> <offset> ... <colorN> <offset> <center> <radius> <focal> <spread>
 
@@ -267,6 +296,7 @@ pen radial <color1> <offset> ... <colorN> <offset> <center> <radius> <focal> <sp
 <focal>    : (optional) focal point (pair!).
 <spread>   : (optional) spread method (word!).
 ----
+
 *Description*
 
 Sets a radial gradient to be used for drawing operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
@@ -276,6 +306,7 @@ The radial gradient will be painted from focal point to the edge of a circle def
 ==== Diamond gradient pen
 
 *Syntax*
+
 ----
 pen diamond <color1> <offset> ... <colorN> <offset> <upper> <lower> <focal> <spread>
 
@@ -286,6 +317,7 @@ pen diamond <color1> <offset> ... <colorN> <offset> <upper> <lower> <focal> <spr
 <focal>    : (optional) focal point (pair!).
 <spread>   : (optional) spread method (word!).
 ----
+
 *Description*
 
 Sets a diamond-shaped gradient to be used for drawing operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
@@ -295,6 +327,7 @@ The diamond gradient will be painted from focal point to the edge of a rectangle
 ==== Pattern pen
 
 *Syntax*
+
 ----
 pen pattern <size> <start> <end> <mode> [<commands>]
 
@@ -304,6 +337,7 @@ pen pattern <size> <start> <end> <mode> [<commands>]
 <mode>     : (optional) tile mode (word!).
 <commands> : block of Draw commands to define the pattern.
 ----
+
 *Description*
 
 Sets a custom shape as pattern to be used for drawing operations. The following values are accepted for the tile mode: `tile` (default), `flip-x`, `flip-y`, `flip-xy`, `clamp`.
@@ -313,6 +347,7 @@ Starting default point is 0x0 and ending point is `<size>`.
 ==== Bitmap pen
 
 *Syntax*
+
 ----
 pen bitmap  <image> <start> <end> <mode>
 
@@ -321,6 +356,7 @@ pen bitmap  <image> <start> <end> <mode>
 <end>   : (optional) lower corner for crop section within image (pair!).
 <mode>  : (optional) tile mode (word!).
 ----
+
 *Description*
 
 Sets an image as pattern to be used for drawing operations. The following values are accepted for the tile mode: `tile` (default), `flip-x`, `flip-y`, `flip-xy`, `clamp`.
@@ -330,9 +366,11 @@ Starting default point is 0x0 and ending point is image's size.
 ==== Turning off the pen
 
 *Syntax*
+
 ----
 pen off
 ----
+
 *Description*
 
 Stop all outline drawing operations for subsequent commands.
@@ -344,11 +382,13 @@ This command defines the filling mode for other commands requiring filling opera
 ==== Color fill
 
 *Syntax*
+
 ----
 fill-pen <color>
 
 <color> : new color to use for filling (tuple! word!).
 ----
+
 *Description*
 
 Selects the color to be used for filling operations. All closed shapes will get filled by the selected color until the fill pen is set to `off`.
@@ -356,6 +396,7 @@ Selects the color to be used for filling operations. All closed shapes will get 
 ==== Linear gradient fill
 
 *Syntax*
+
 ----
 fill-pen linear <color1> <offset> ... <colorN> <offset> <start> <end> <spread>
 
@@ -365,6 +406,7 @@ fill-pen linear <color1> <offset> ... <colorN> <offset> <start> <end> <spread>
 <end>      : (optional unless <start>) ending point (pair!).
 <spread>   : (optional) spread method (word!).
 ----
+
 *Description*
 
 Sets a linear gradient to be used for filling operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
@@ -375,6 +417,7 @@ the gradient will be paint along a horizontal line inside the shape currently dr
 ==== Radial gradient fill
 
 *Syntax*
+
 ----
 fill-pen radial <color1> <offset> ... <colorN> <offset> <center> <radius> <focal> <spread>
 
@@ -385,6 +428,7 @@ fill-pen radial <color1> <offset> ... <colorN> <offset> <center> <radius> <focal
 <focal>    : (optional) focal point (pair!).
 <spread>   : (optional) spread method (word!).
 ----
+
 *Description*
 
 Sets a radial gradient to be used for filling operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
@@ -394,6 +438,7 @@ The radial gradient will be painted from focal point to the edge of a circle def
 ==== Diamond gradient fill
 
 *Syntax*
+
 ----
 fill-pen diamond <color1> <offset> ... <colorN> <offset> <upper> <lower> <focal> <spread>
 
@@ -404,6 +449,7 @@ fill-pen diamond <color1> <offset> ... <colorN> <offset> <upper> <lower> <focal>
 <focal>    : (optional) focal point (pair!).
 <spread>   : (optional) spread method (word!).
 ----
+
 *Description*
 
 Sets a diamond-shaped gradient to be used for filling operations. The following values are accepted for the spread method: `pad`, `repeat`, `reflect` (currently `pad` is same as `repeat` for Windows platform).
@@ -413,6 +459,7 @@ The diamond gradient will be painted from focal point to the edge of a rectangle
 ==== Pattern fill
 
 *Syntax*
+
 ----
 fill-pen pattern <size> <start> <end> <mode> [<commands>]
 
@@ -422,6 +469,7 @@ fill-pen pattern <size> <start> <end> <mode> [<commands>]
 <mode>     : (optional) tile mode (word!).
 <commands> : block of Draw commands to define the pattern.
 ----
+
 *Description*
 
 Sets a custom shape as pattern to be used for filling operations. The following values are accepted for the tile mode: `tile` (default), `flip-x`, `flip-y`, `flip-xy`, `clamp`.
@@ -431,6 +479,7 @@ Starting default point is 0x0 and ending point is `<size>`.
 ==== Bitmap fill
 
 *Syntax*
+
 ----
 fill-pen bitmap  <image> <start> <end> <mode>
 
@@ -439,6 +488,7 @@ fill-pen bitmap  <image> <start> <end> <mode>
 <end>   : (optional) lower corner for crop section within image (pair!).
 <mode>  : (optional) tile mode (word!).
 ----
+
 *Description*
 
 Sets an image as pattern to be used for filling operations. The following values are accepted for the tile mode: `tile` (default), `flip-x`, `flip-y`, `flip-xy`, `clamp`.
@@ -448,9 +498,11 @@ Starting default point is 0x0 and ending point is image's size.
 ==== Turning off the filling
 
 *Syntax*
+
 ----
 fill-pen off
 ----
+
 *Description*
 
 Stop all filling operations for subsequent commands.
@@ -458,11 +510,13 @@ Stop all filling operations for subsequent commands.
 === Line-width 
 
 *Syntax*
+
 ----
 line-width <value>
 
 <value> : new line width in pixels (integer!).
 ----
+
 *Description*
 
 Sets the new width for line operations.
@@ -470,11 +524,13 @@ Sets the new width for line operations.
 === Line-join 
 
 *Syntax*
+
 ----
 line-join <mode>
 
 <mode> : new line joining mode (word!).
 ----
+
 *Description*
 
 Sets the new line joining mode for line operations. Following values are accepted:
@@ -491,11 +547,13 @@ NOTE: `miter-bevel` mode selects automatically one or the other joining mode dep
 === Line-cap 
 
 *Syntax*
+
 ----
 line-cap <mode>
 
 <mode> : new line cap mode (word!).
 ----
+
 *Description*
 
 Sets the new line's ending cap mode for line operations. Following values are accepted:
@@ -509,11 +567,13 @@ image::../images/line-cap.png[Line-cap,align="center"]
 === Anti-alias 
 
 *Syntax*
+
 ----
 anti-alias <mode>
 
 <mode> : `on` to enable it or `off` to disable it.
 ----
+
 *Description*
 
 Turns on/off the anti-aliasing mode for following Draw commands.
@@ -523,6 +583,7 @@ NOTE: Anti-aliasing gives nicer visual rendering, but degrades performance.
 === Matrix 
 
 *Syntax*
+
 ----
 matrix <matrix-setup>
 matrix 'pen <matrix-setup>
@@ -530,15 +591,19 @@ matrix 'fill-pen <matrix-setup>
 
 <matrix-setup> : the matrix which is pre/post-multiplied to current matrix (block!).
 ----
+
 *Description*
 
 Performs matrix multiplication. The current transformation matrix is pre-multiplied by this matrix.
 
 The `matrix-setup` block must have 6 numbers (number!) in it. 
+
 ----
 matrix [a b c d e f]
 ----
+
 The block values are used internally for building following transformation matrix:
+
 ----
 |a c e|
 |b d f|
@@ -550,11 +615,13 @@ When the `'pen` or `'fill-pen` lit-words are used, the multiplication is applied
 === Matrix-order
 
 *Syntax*
+
 ----
 matrix-order <mode>
 
 <mode> : 'append or 'prepend (word!).
 ----
+
 *Description*
 
 Defines if new matrices in subsequent matrix operations, are pre-multiplied (`prepend`, default mode) or post-multiplied (`append`) to the current matrix.
@@ -562,11 +629,13 @@ Defines if new matrices in subsequent matrix operations, are pre-multiplied (`pr
 === Reset-matrix 
 
 *Syntax*
+
 ----
 reset-matrix
 reset-matrix 'pen
 reset-matrix 'fill-pen
 ----
+
 *Description*
 
 Resets the current transformation matrix to a unit matrix.
@@ -582,11 +651,13 @@ When the `'pen` or `'fill-pen` lit-words are used, the reset is applied respecti
 === Invert-matrix 
 
 *Syntax*
+
 ----
 invert-matrix
 invert-matrix 'pen
 invert-matrix 'fill-pen
 ----
+
 *Description*
 
 Applies an algebraic matrix inversion operation on the current transformation matrix.
@@ -596,11 +667,13 @@ When the `'pen` or `'fill-pen` lit-words are used, the inversion is applied resp
 === Push 
 
 *Syntax*
+
 ----
 push <draw-block>
 
 <draw-block> : block of Draw commands (block!).
 ----
+
 *Description*
 
 Saves the current state (transformations, clipping region, and pen settings) on the stack. You can then change the current transformation matrix, pens etc. inside the PUSH command block. After the PUSH command block, the current state is restored by pop from the stack. The PUSH command can be nested.
@@ -608,6 +681,7 @@ Saves the current state (transformations, clipping region, and pen settings) on 
 === Rotate 
 
 *Syntax*
+
 ----
 rotate <angle> <center> [<commands>]
 rotate 'pen <angle>
@@ -617,6 +691,7 @@ rotate 'fill-pen <angle>
 <center>   : (optional) center of rotation (pair!).
 <commands> : (optional) Draw dialect commands.
 ----
+
 *Description*
 
 Sets the clockwise rotation about a given point, in degrees. If optional `center` is not supplied, the rotate is about the origin of the current user coordinate system. Negative numbers can be used for counter-clockwise rotation. When a block is provided as last argument, the rotation will be applied only to the commands in that block.
@@ -626,6 +701,7 @@ When the `'pen` or `'fill-pen` lit-words are used, the rotation is applied respe
 === Scale 
 
 *Syntax*
+
 ----
 scale <scale-x> <scale-y> [<commands>]
 scale 'pen <scale-x> <scale-y>
@@ -635,6 +711,7 @@ scale 'fill-pen <scale-x> <scale-y>
 <scale-y>  : the scale amount in Y (number!).
 <commands> : (optional) Draw dialect commands.
 ----
+
 *Description*
 
 Sets the scale amounts. The values given are multipliers; use values greater than one to increase the scale; use values less than one to decrease it. When a block is provided as last argument, the scaling will be applied only to the commands in that block.
@@ -644,6 +721,7 @@ When the `'pen` or `'fill-pen` lit-words are used, the scaling is applied respec
 === Translate 
 
 *Syntax*
+
 ----
 translate <offset> [<commands>]
 translate 'pen <offset>
@@ -652,6 +730,7 @@ translate 'fill-pen <offset>
 <offset>   : the translation amounts (pair!).
 <commands> : (optional) Draw dialect commands.
 ----
+
 *Description*
 
 Sets the origin for drawing commands. Multiple translate commands will have a cumulative effect. When a block is provided as last argument, the translation will be applied only to the commands in that block.
@@ -661,6 +740,7 @@ When the `'pen` or `'fill-pen` lit-words are used, the translation is applied re
 === Skew 
 
 *Syntax*
+
 ----
 skew <skew-x> <skew-y> [<commands>]
 skew 'pen <skew-x> <skew-y>
@@ -670,6 +750,7 @@ skew 'fill-pen <skew-x> <skew-y>
 <skew-y>   : (optional) skew along the y-axis in degrees (integer! float!).
 <commands> : (optional) Draw dialect commands.
 ----
+
 *Description*
 
 Sets a coordinate system skewed from the original by the given number of degrees. If `<skew-y>` is not provided, it is assumed to be zero. When a block is provided as last argument, the skewing will be applied only to the commands in that block.
@@ -679,6 +760,7 @@ When the `'pen` or `'fill-pen` lit-words are used, the skewing is applied respec
 === Transform 
 
 *Syntax*
+
 ----
 transform <angle> <center> <scale-x> <scale-y> <translation> [<commands>]
 transform 'pen <angle> <center> <scale-x> <scale-y> <translation>
@@ -691,6 +773,7 @@ transform 'fill-pen <angle> <center> <scale-x> <scale-y> <translation>
 <translation> : the translation amounts (pair!).
 <commands>    : (optional) Draw dialect commands.
 ----
+
 *Description*
 
 Sets a transformation such as translation, scaling, and rotation. When a block is provided as last argument, the transformation will be applied only to the commands in that block.
@@ -700,6 +783,7 @@ When the `'pen` or `'fill-pen` lit-words are used, the transformation is applied
 === Clip
 
 *Syntax*
+
 ----
 clip <start> <end> <mode> [<commands>]
 clip [<shape>] <mode> [<commands>]
@@ -710,6 +794,7 @@ clip [<shape>] <mode> [<commands>]
 <commands> : (optional) Draw dialect commands.
 <shape>    : Shape dialect commands.
 ----
+
 *Description*
 
 Defines a clipping rectangular region defined with two points (start and end) or an arbitrarily shaped region defined by a block of Shape sub-dialect commands. Such clipping applies to all subsequent Draw commands. When a block is provided as last argument, the clipping will be applied only to the commands in that block.
@@ -726,11 +811,13 @@ Additionally, the combining mode between a new clipping region and the previous 
 == Shape commands
 
 *Syntax*
+
 ----
 shape [<commands>]
 
 <commands> : shape dialect commands.
 ----
+
 *Description*
 
 The `shape` keywords gives access to the Shape sub-dialect drawing commands. The specific features of this drawing dialect are: 
@@ -746,12 +833,14 @@ NOTE: All drawing commands are using absolute coordinates by default, using the 
 === Move
 
 *Syntax*
+
 ----
  move <position>            (absolute)
 'move <position>            (relative)
 
 <position> : new pen position (pair!).
 ----
+
 *Description*
 
 Moves the pen to a new position. No drawing happens.
@@ -759,12 +848,14 @@ Moves the pen to a new position. No drawing happens.
 === Line
 
 *Syntax*
+
 ----
  line <point> <point> ...   (absolute)
 'line <point> <point> ...   (relative)
 
 <point> : coordinates of a point (pair!).
 ----
+
 *Description*
 
 Draws a line between two points. If more points are specified, additional lines are drawn, connecting each point in the provided order.
@@ -772,6 +863,7 @@ Draws a line between two points. If more points are specified, additional lines 
 === Arc
 
 *Syntax*
+
 ----
  arc <end> <radius-x> <radius-y> <angle> sweep closed       (absolute)
 'arc <end> <radius-x> <radius-y> <angle> sweep closed       (relative)
@@ -784,6 +876,7 @@ sweep      : (optional) draw the arc in the positive angle direction.
 large      : (optional) produces an inflated arc (goes with 'sweep option).
 
 ----
+
 *Description*
 
 Draws the arc of a circle between the current pen position and the end point, using radius values. The arc is defined by one angle value.
@@ -791,12 +884,14 @@ Draws the arc of a circle between the current pen position and the end point, us
 === Curve
 
 *Syntax*
+
 ----
  curve <point> <point> <point> ...   (absolute)
 'curve <point> <point> <point> ...   (relative)
 
 <point> : coordinates of a point (pair!).
 ----
+
 *Description*
 
 Draws a cubic Bezier curve from a sequence of points, starting from the current pen position. At least 3 points are required to produce a curve (the first point is the implicit starting point).
@@ -804,12 +899,14 @@ Draws a cubic Bezier curve from a sequence of points, starting from the current 
 === Curv
 
 *Syntax*
+
 ----
  curv <point> <point> ...   (absolute)
 'curv <point> <point> ...   (relative)
 
 <point> : coordinates of a point (pair!).
 ----
+
 *Description*
 
 Draws a smooth cubic Bezier curve from a sequence of points, starting from the current pen position. At least 2 points are required to produce a curve (the first point is the implicit starting point).
@@ -821,12 +918,14 @@ NOTE: From http://www.w3.org/TR/SVG11/paths.html
 === Qcurve
 
 *Syntax*
+
 ----
  qcurve <point> <point> ...   (absolute)
 'qcurve <point> <point> ...   (relative)
 
 <point> : coordinates of a point (pair!).
 ----
+
 *Description*
 
 Draws a quadratic Bezier curve from a sequence of points, starting from the current pen position. At least 2 points are required to produce a curve (the first point is the implicit starting point).
@@ -834,12 +933,14 @@ Draws a quadratic Bezier curve from a sequence of points, starting from the curr
 === Qcurv
 
 *Syntax*
+
 ----
  qcurv <point>   (absolute)
 'qcurv <point>   (relative)
 
 <point> : coordinates of the ending point (pair!).
 ----
+
 *Description*
 
 Draws a smooth quadratic Bezier curve from the current pen position to the specified point.
@@ -849,6 +950,7 @@ NOTE: See: http://www.w3.org/TR/SVG11/paths.html
 === Hline
 
 *Syntax*
+
 ----
  hline <end-x>   (absolute)
 'hline <length>  (relative)
@@ -856,6 +958,7 @@ NOTE: See: http://www.w3.org/TR/SVG11/paths.html
 <end-x>  : ending position along X axis (integer! float!).
 <length> : length of the line segment (integer! float!).
 ----
+
 *Description*
 
 Draws a horizontal line from the current pen position.
@@ -863,6 +966,7 @@ Draws a horizontal line from the current pen position.
 === Vline
 
 *Syntax*
+
 ----
  vline <end-y>   (absolute)
 'vline <length>  (relative)
@@ -870,6 +974,7 @@ Draws a horizontal line from the current pen position.
 <end-y>  : ending position along Y axis (integer! float!).
 <length> : length of the line segment (integer! float!).
 ----
+
 *Description*
 
 Draws a vertical line from the current pen position.
@@ -927,6 +1032,7 @@ NOTE: If the Draw block length preceeding a set-word is changed, the original po
 It is possible to render a Draw block directly to an image using the `draw` function.
 
 *Syntax*
+
 ----
 draw <size> <spec>
 draw <image> <spec>
@@ -935,6 +1041,7 @@ draw <image> <spec>
 <image> : image to use as canvas (image!).
 <spec>  : block of Draw commands (block!).
 ----
+
 *Description*
 
 Renders the provided Draw commands to an existing or a new image. The image value is returned by the function.
@@ -944,6 +1051,7 @@ Renders the provided Draw commands to an existing or a new image. The image valu
 Fill-pen also supports a deprecated API which exists only for sake of compatibility with Rebol/Draw, it should not be used by new Red scripts.
 
 *Syntax*
+
 ----
 fill-pen linear <grad-offset> <grad-start-rng> <grad-stop-rng>
          <grad-angle> <grad-scale-x> <grad-scale-y> <grad-color> <offset>
@@ -968,6 +1076,7 @@ fill-pen diamond <grad-offset> <grad-focal> <grad-radius>
 <grad-scale-y>   : (optional) scale Y factor (integer! float!).
 <grad-color>     : color to use for gradient filling (tuple! word!).
 ----
+
 *Description*
 
 Sets the color gradient to be used for filling operations. The following values are accepted for the type: `linear`, `radial`, `diamond`.
@@ -983,6 +1092,7 @@ NOTE: the gradient can be defined by up to 256 colors.
 == Graphics source code 
 
 The graphics in this documentation are generated using Red and Draw dialect, here is the source code (you can copy/paste it in a Red console to try/play/improve it):
+
 ----
 Red [
 	Title:	"Graphics generator for Draw documentation"

--- a/en/libred.adoc
+++ b/en/libred.adoc
@@ -23,14 +23,19 @@ Samples of libRed usage can be found https://github.com/red/red/tree/master/test
 == Building libRed
 
 Building your local version of libRed is simple:
+
 ----
 red build libRed
 ----
+
 or from Rebol's console and Red sources:
+
 ----
 rc "build libRed"
 ----
+
 Those command-lines will build the libRed version for C language (using the `cdecl` ABI). If you need the `stdcall` ABI (for Microsoft apps compatibility), you need to use:
+
 ----
 red build libRed stdcall
 ----
@@ -38,6 +43,7 @@ red build libRed stdcall
 == Value references
 
 Red values can be returned by libRed function calls. They are represented as _opaque_ 32-bit references. Those references are short-lived, so they are suitable only for restricted local use, like passing that reference to another libRed function call. Setting such references to host variables is possible, but it should be used *immediately after*. Those references are using a specific memory manager that will only keep references alive for about the next 50 API calls. For example:
+
 ----
 long a, blk;
 
@@ -65,17 +71,21 @@ A libRed _instance_ needs to be created in order to use any function from the AP
 NOTE: Currently, only a single libRed session per process is allowed. It is intended that this will be extended in the future to allow multi-instances support.
 
 ==== redOpen()
+
 ----
 void redOpen(void)
 ----
+
 Initializes a new Red runtime library session. This function _must_ be called before calling any other API function. It is safe to call it several times in the same process, only one session will be opened anyway.
 
 NOTE: If another function is called before `redOpen`, the return value of that function will be `-2`, indicating an illegal access attempt.
 
 ==== redClose()
+
 ----
 void redClose(void)
 ----
+
 Terminates the current Red runtime library session, freeing all allocated resources.
 
 === Running Red code
@@ -83,12 +93,15 @@ Terminates the current Red runtime library session, freeing all allocated resour
 The host software can run Red code directly, using different level of control, from providing Red code in text form to be evaluated, down to calling any Red function directly, and passing arguments constructed on the host side.
 
 ==== redDo()
+
 ----
 red_value redDo(const char* source)
 ----
+
 Evaluates the Red expression passed as string and returns the last Red value.
 
 *Examples*
+
 ----
 redDo("a: 123");
 
@@ -100,35 +113,44 @@ redDo(sprintf(s, "view [text \"%s\"]", caption));
 ----
 
 ==== redDoFile()
+
 ----
 red_value redDoFile(const char* filename)
 ----
+
 Loads and evaluates the Red script referred by _filename_ and returns the last Red value. The _filename_ is formatted using Red OS-independent conventions (basically Unix-style).
 
 *Examples*
+
 ----
 redDoFile("hello.red");
 redDoFile("/c/dev/red/demo.red");
 ----
 
 ==== redDoBlock()
+
 ----
 red_value redDoBlock(red_block code)
 ----
+
 Evaluates the argument block and returns the last Red value.
 
 *Example*
+
 ----
 redDoBlock(redBlock(redWord("print"), redInteger(42)));
 ----
 
 ==== redCall()
+
 ----
 red_value redCall(red_word name, ...)
 ----
+
 Invokes the Red function (of `any-function!` type) referenced by _name_ word, passing to it any required arguments (as Red values). Returns the function's last Red value. The arguments list *must* terminate with a `null` or `0` value, as end marker.
 
 *Example*
+
 ----
 redCall(redWord("random"), redInteger(6), 0);     // returns a random integer! value between 1 and 6
 ----
@@ -138,12 +160,15 @@ redCall(redWord("random"), redInteger(6), 0);     // returns a random integer! v
 Responding to an event occuring in Red, or redirecting some Red calls to the host side (like redirecting `print` or `ask`) requires a way to call back a host function from Red side. This can be achieved using `redRoutine()` function.
 
 ==== redRoutine()
+
 ----
 red_value redRoutine(red_word name, const char* spec, void* func_ptr)
 ----
+
 Defines a new Red routine named _name_, with _spec_ as specification block and _func-ptr_ C function pointer as body. The C function *must* return a Red value (`redUnset()` can be used to signify that the return value is not used).
 
 *Example*
+
 ----
 #include "red.h"
 #include <stdio.h>
@@ -164,12 +189,15 @@ int main(void) {
 Many functions from the libRed API require passing Red values (as _references_). The following functions are simple constructors for the most commonly used datatypes.
 
 ==== redSymbol()
+
 ----
 long redSymbol(const char* word)
 ----
+
 Returns a symbol ID associated with the loaded _word_ (provided as a C string). This ID can then be passed to other libRed API functions requiring a symbol ID instead of a word value.
 
 *Example*
+
 ----
 long a = redSymbol("a");
 redSet(a, redInteger(42));
@@ -177,87 +205,114 @@ printf("%l\n", redGet(a));
 ----
 
 ==== redUnset()
+
 ----
 red_unset redUnset(void)
 ----
+
 Returns an `unset!` value.
 
 ==== redNone()
+
 ----
 red_none redNone(void)
 ----
+
 Returns a `none!` value.
 
 ==== redLogic()
+
 ----
 red_logic redLogic(long logic)
 ----
+
 Returns a `logic!` value. A _logic_ value of `0` gives a `false` value, all other values give a `true`.
 
 ==== redDatatype()
+
 ----
 red_datatype redDatatype(long type)
 ----
+
 Returns a `datatype!` value corresponding to the _type_ ID, which is a value from `RedType` enumeration.
 
 ==== redInteger()
+
 ----
 red_integer redInteger(long number)
 ----
+
 Returns an `integer!` value from _number_.
 
 ==== redFloat()
+
 ----
 red_float redFloat(double number)
 ----
+
 Returns a `float!` value from _number_.
 
 ==== redPair()
+
 ----
 red_pair redPair(long x, long y)
 ----
+
 Returns a `pair!` value from two integer values.
 
 ==== redTuple()
+
 ----
 red_tuple redTuple(long r, long g, long b)
 ----
+
 Returns a `tuple!` value from three integer values (usually for representing RGB colors). Passed arguments will be truncated to 8-bit values.
 
 ==== redTuple4()
+
 ----
 red_tuple redTuple4(long r, long g, long b, long a)
 ----
+
 Returns a `tuple!` value from four integer values (usually for representing RGBA colors). Passed arguments will be truncated to 8-bit values.
 
 ==== redBinary()
+
 ----
 red_binary redBinary(const char* buffer, long bytes)
 ----
+
 Returns a `binary!` value from a memory `buffer` pointer and the buffer's length in bytes. The input buffer will be copied internally.
 
 ==== redImage()
+
 ----
 red_image redImage(long width, long height, const void* buffer, long format)
 ----
+
 Returns an `image!` value from a memory `buffer` pointer. Image's size is defined in pixels by `width` and `height`. The input buffer will be copied internally. Accepted buffer formats are:
 
 * `RED_IMAGE_FORMAT_RGB`: 24-bit per pixel.
 * `RED_IMAGE_FORMAT_ARGB`: 32-bit per pixel, alpha channel leading.
 
 ==== redString()
+
 ----
 red_string redString(const char* string)
 ----
+
 Returns a `string!` value from _string_ pointer. Default expected encoding for the argument string is UTF-8. Other encodings can be defined using the `redSetEncoding()` function.
 
 ==== redWord()
+
 ----
 red_word redWord(const char* word)
 ----
+
 Returns a `word!` value from a C string. Default expected encoding for the argument string is UTF-8. Other encodings can be defined using the `redSetEncoding()` function. Strings which cannot be loaded as words will return an `error!` value.
 
 ==== redBlock()
+
 ----
 red_block redBlock(red_value v,...)
 ----
@@ -265,12 +320,14 @@ red_block redBlock(red_value v,...)
 Returns a new `block!` series built from the arguments list. The list *must* terminate with a `null` or `0` value, as end marker.
 
 *Examples*
+
 ----
 redBlock(0);                                  // Creates an empty block
 redBlock(redInteger(42), redWord("hi"), 0);   // Creates [42 hi] block
 ----
 
 ==== redPath()
+
 ----
 red_path redPath(red_value v, ...)
 ----
@@ -278,6 +335,7 @@ red_path redPath(red_value v, ...)
 Returns a new `path!` series built from the arguments list. The list *must* terminate with a `null` or `0` value, as end marker.
 
 *Example*
+
 ----
 redDo("a: [b 123]");
 long res = redGetPath(redPath(redWord("a"), redWord("b"), 0));
@@ -285,6 +343,7 @@ printf("%l\n", redCInt32(res));    // will output 123
 ----
 
 ==== redLoadPath()
+
 ----
 red_path redLoadPath(const char* path)
 ----
@@ -292,11 +351,13 @@ red_path redLoadPath(const char* path)
 Returns a `path!` series built from a path expressed as a C string. This provides a quick way to build paths without constructing individually each element.
 
 *Example*
+
 ----
 redGetPath(redLoadPath("a/b"));    // Creates and evaluates the a/b path! value.
 ----
 
 ==== redMakeSeries()
+
 ----
 red_value redMakeSeries(unsigned long type, unsigned long slots)
 ----
@@ -304,6 +365,7 @@ red_value redMakeSeries(unsigned long type, unsigned long slots)
 Returns a new `series!` of type _type_ and enough size to store _slots_ elements. This is a generic series constructor function. The type needs to be one of the `RedType` enumeration values. 
 
 *Examples*
+
 ----
 redMakeSeries(RED_TYPE_PAREN, 2);  // Creates a paren! series
 
@@ -317,6 +379,7 @@ redAppend(path, redInteger(2));    // Now path is `a/2:`
 Converting Red values to _host_ side is possible, though, restricted by the limited number of types in C language.
 
 ==== redCInt32()
+
 ----
 long redCInt32(red_integer number)
 ----
@@ -324,6 +387,7 @@ long redCInt32(red_integer number)
 Returns a 32-bit signed integer from a Red `integer!` value.
 
 ==== redCDouble()
+
 ----
 double redCDouble(red_float number)
 ----
@@ -331,6 +395,7 @@ double redCDouble(red_float number)
 Returns a C double floating point value from a Red `float!` value.
 
 ==== redCString()
+
 ----
 const char* redCString(red_string string)
 ----
@@ -338,6 +403,7 @@ const char* redCString(red_string string)
 Returns a UTF-8 string buffer pointer from a Red `string!` value. Other encodings can be defined using the `redSetEncoding()` function.
 
 ==== redTypeOf()
+
 ----
 long redTypeOf(red_value value)
 ----
@@ -349,6 +415,7 @@ Returns the type ID of a Red value. The type ID values are defined in the `RedTy
 It is possible to call any Red function using `redCall`, though, for the most common actions, some shortcuts are provided for convenience and better performances.
 
 ==== redAppend()
+
 ----
 red_value redAppend(red_series series, red_value value)
 ----
@@ -356,6 +423,7 @@ red_value redAppend(red_series series, red_value value)
 Appends a _value_ to a _series_ and returns the series at head.
 
 ==== redChange()
+
 ----
 red_value redChange(red_series series, red_value value)
 ----
@@ -363,6 +431,7 @@ red_value redChange(red_series series, red_value value)
 Changes a _value_ in _series_ and returns the series after the changed part.
 
 ==== redClear()
+
 ----
 red_value redClear(red_series series)
 ----
@@ -370,6 +439,7 @@ red_value redClear(red_series series)
 Removes _series_ values from current index to tail and returns series at new tail.
 
 ==== redCopy()
+
 ----
 red_value redCopy(red_value value)
 ----
@@ -377,6 +447,7 @@ red_value redCopy(red_value value)
 Returns a copy of a non-scalar value.
 
 ==== redFind()
+
 ----
 red_value redFind(red_series series, red_value value)
 ----
@@ -384,6 +455,7 @@ red_value redFind(red_series series, red_value value)
 Returns the _series_ where a _value_ is found, or `none`.
 
 ==== redIndex()
+
 ----
 red_value redIndex(red_series series)
 ----
@@ -391,6 +463,7 @@ red_value redIndex(red_series series)
 Returns the current index of _series_ relative to the head, or of word in a context. 
 
 ==== redLength()
+
 ----
 red_value redLength(red_series series)
 ----
@@ -398,6 +471,7 @@ red_value redLength(red_series series)
 Returns the number of values in the _series_, from the current index to the tail.
 
 ==== redMake()
+
 ----
 red_value redMake(red_value proto, red_value spec)
 ----
@@ -405,6 +479,7 @@ red_value redMake(red_value proto, red_value spec)
 Returns a new value made from a _spec_ for that _proto_'s type. 
 
 ==== redMold()
+
 ----
 red_value redMold(red_value value)
 ----
@@ -412,6 +487,7 @@ red_value redMold(red_value value)
 Returns a source format string representation of a value.
 
 ==== redPick()
+
 ----
 red_value redPick(red_series series, red_value value)
 ----
@@ -419,6 +495,7 @@ red_value redPick(red_series series, red_value value)
 Returns the _series_ at a given index _value_. 
 
 ==== redPoke()
+
 ----
 red_value redPoke(red_series series, red_value index, red_value value)
 ----
@@ -426,6 +503,7 @@ red_value redPoke(red_series series, red_value index, red_value value)
 Replaces the _series_ at a given _index_ with the _value_, and returns the new value.
 
 ==== redPut()
+
 ----
 red_value redPut(red_series series, red_value index, red_value value)
 ----
@@ -433,6 +511,7 @@ red_value redPut(red_series series, red_value index, red_value value)
 Replaces the value following a key in a _series_ or `map!` value, and returns the new value.
 
 ==== redRemove()
+
 ----
 red_value redRemove(red_series series)
 ----
@@ -440,6 +519,7 @@ red_value redRemove(red_series series)
 Removes a value at current _series_ index and returns series after removal.
 
 ==== redSelect()
+
 ----
 red_value redSelect(red_series series, red_value value)
 ----
@@ -447,6 +527,7 @@ red_value redSelect(red_series series, red_value value)
 Find a _value_ in a _series_ and return the next value, or `none`.
 
 ==== redSkip()
+
 ----
 red_value redSkip(red_series series, red_integer offset)
 ----
@@ -454,6 +535,7 @@ red_value redSkip(red_series series, red_integer offset)
 Returns the _series_ relative to the current index.
 
 ==== redTo()
+
 ----
 red_value redTo(red_value proto, red_value spec)
 ----
@@ -465,6 +547,7 @@ Converts _spec_ value to a datatype specified by _proto_.
 Setting a Red word or getting the value of a Red word is the most direct way to pass values between the _host_ and Red runtime environment.
 
 ==== redSet()
+
 ----
 red_value redSet(long id, red_value value)
 ----
@@ -472,6 +555,7 @@ red_value redSet(long id, red_value value)
 Sets a word defined from _id_ symbol to _value_. The word created from the symbol is bound to global context. _value_ is returned by this function.
 
 ==== redGet()
+
 ----
 red_value redGet(long id)
 ----
@@ -483,6 +567,7 @@ Returns the value of a word defined from _id_ symbol. The word created from the 
 Paths are very flexible way to access data in Red, so they have their dedicated accessor functions in libRed. Notably, they allow access to words in object contexts.
 
 ==== redSetPath()
+
 ----
 red_value redSetPath(red_path path, red_value value)
 ----
@@ -490,6 +575,7 @@ red_value redSetPath(red_path path, red_value value)
 Sets a _path_ to a _value_ and returns that _value_.
 
 ==== redGetPath()
+
 ----
 red_value redGetPath(red_path path)
 ----
@@ -503,6 +589,7 @@ When multiple setting/getting accesses are needed on an object's fields, using t
 NOTE: These accessors can work with any other associated array types, not just `object!`. So passing a `map!` is allowed too.
 
 ==== redSetField()
+
 ----
 red_value redSetField(red_value object, long field, red_value value)
 ----
@@ -510,6 +597,7 @@ red_value redSetField(red_value object, long field, red_value value)
 Sets an _object_'s _field_ to a _value_ and returns that _value_. The _field_ argument is a symbol ID created using `redSymbol()`.
 
 ==== redGetField()
+
 ----
 red_value redGetField(red_value obj, long field)
 ----
@@ -521,6 +609,7 @@ Returns the _value_ stored in the _object_'s _field_. The _field_ argument is a 
 Some handy debugging functions are also provided. Most of them require a system shell window for the output, though, it is possible to force the opening of a log window, or redirect the output to a file.
 
 ==== redPrint()
+
 ----
 void redPrint(red_value value)
 ----
@@ -528,6 +617,7 @@ void redPrint(red_value value)
 Prints the _value_ on the standard output, or in the debug console if opened.
 
 ==== redProbe()
+
 ----
 red_value redProbe(red_value value)
 ----
@@ -535,6 +625,7 @@ red_value redProbe(red_value value)
 Probes the _value_ on the standard output, or in the debug console if opened. The _value_ is returned from this function call.
 
 ==== redHasError()
+
 ----
 red_value redHasError(void)
 ----
@@ -542,6 +633,7 @@ red_value redHasError(void)
 Returns an `error!` value if an error has occured in previous API call, or `null` if there no error occured.
 
 ==== redFormError()
+
 ----
 const char* redFormError(void)
 ----
@@ -549,6 +641,7 @@ const char* redFormError(void)
 Returns a UTF-8 string pointer containing a formatted error if an error has occured, or `null` if there no error occured.
 
 ==== redOpenLogWindow()
+
 ----
 int redOpenLogWindow(void)
 ----
@@ -558,6 +651,7 @@ Opens the log window and redirects all the Red printing output to that window. T
 NOTE: Only for Windows platforms.
 
 ==== redCloseLogWindow()
+
 ----
 int redCloseLogWindow(void)
 ----
@@ -567,6 +661,7 @@ Closes the log window. Calling this function when the log window is already clos
 NOTE: Only for Windows platforms.
 
 ==== redOpenLogFile()
+
 ----
 void redOpenLogFile(const string *name)
 ----
@@ -574,6 +669,7 @@ void redOpenLogFile(const string *name)
 Redirects the output from Red printing functions to the file specified by _name_. A relative or absolute path can be provided in _name_ using OS-specific file path format.
 
 ==== redCloseLogFile()
+
 ----
 void redCloseLogFile(void)
 ----
@@ -585,6 +681,7 @@ NOTE: Currently, the log file *must* be closed on exit, otherwise a lock is kept
 === Datatypes definition
 
 Some functions from libRed API can refer to Red datatypes: `redTypeOf()`, `redMakeSeries()` and `redDatatype()`. Red datatypes are represented on the host side, as an enumeration (`RedType`), where types are names using the following scheme:
+
 ----
 RED_TYPE_<DATATYPE>
 ----
@@ -612,6 +709,7 @@ The Visual Basic API can be used both for VB and VBA (from MS Office application
 ==== Setting up
 
 In order to use libRed with VB/VBA, you need a version of the libRed binary that is compiled for `stdcall` ABI. If you need to recompile such version:
+
 ----
 red build libRed stdcall
 ----
@@ -619,25 +717,31 @@ red build libRed stdcall
 You will also need to import the https://github.com/red/red/blob/master/libRed/libRed.bas[`libRed.bas`] module file in your project.
 
 ==== redLogic()
+
 ----
 Function redLogic(bool As Boolean) As Long
 ----
+
 Returns a Red `logic!` value constructed from a VB `boolean` value.
 
 
 ==== redBlockVB()
+
 ----
 Function redBlockVB(ParamArray args() As Variant) As Long
 ----
+
 Returns a new `block!` series built from the arguments list. The arguments number is variable and composed of VisualBasic values only. 
 
 *Examples*
+
 ----
 redProbe redBlockVB()              ' Creates an empty block
 redProbe redBlockVB(42, "hello")   ' Creates the [42 "hello" hi] block
 ----
 
 ==== redPathVB()
+
 ----
 Function redPathVB(ParamArray args() As Variant) As Long
 ----
@@ -652,12 +756,15 @@ Debug.print redCInt32(res))        ' will output 123
 ----
 
 ==== redCallVB()
+
 ----
 Function redCallVB(ParamArray args() As Variant) As Long
 ----
+
 Invokes the Red function (of `any-function!` type) referenced by the string passed (first argument), passing it eventually some arguments (as VisualBasic values). Returns the function's last value. The arguments number is variable and composed of VisualBasic values only.
 
 *Example*
+
 ----
 redCallVB("random", 6);            ' returns a random integer! value between 1 and 6
 ----
@@ -667,6 +774,7 @@ redCallVB("random", 6);            ' returns a random integer! value between 1 a
 Creating a VisualBasic function that can be called from Red side is done like in C API, using the `redRoutine()` call. The last argument for that function is a function pointer. In VB, such pointer can be acquired only for a function defined in a _module_, but not in a _UserForm_.
 
 This is the callback used by the Excel "Red Console" demo:
+
 ----
 Sub RegisterConsoleCB()
     redRoutine redWord("print"), "[msg [string!]]", AddressOf onConsolePrint

--- a/en/libred.adoc
+++ b/en/libred.adoc
@@ -70,7 +70,7 @@ void redOpen(void)
 ----
 Initializes a new Red runtime library session. This function _must_ be called before calling any other API function. It is safe to call it several times in the same process, only one session will be opened anyway.
 
-Note: If another function is called before `redOpen`, the return value of that function will be `-2`, indicating an illegal access attempt.
+NOTE: If another function is called before `redOpen`, the return value of that function will be `-2`, indicating an illegal access attempt.
 
 ==== redClose()
 ----
@@ -500,7 +500,7 @@ Returns the _value_ referenced by the _path_.
 
 When multiple setting/getting accesses are needed on an object's fields, using the object value directly instead of building paths is simpler and preferable. The following two functions are tailored for such access.
 
-Note: these accessors can work with any other associated array types, not just `object!`. So passing a `map!` is allowed too.
+NOTE: These accessors can work with any other associated array types, not just `object!`. So passing a `map!` is allowed too.
 
 ==== redSetField()
 ----

--- a/en/map.adoc
+++ b/en/map.adoc
@@ -7,26 +7,32 @@
 A map represents an associative array of key/value pairs. It provides a fast read access (using a hashtable internally) and a convenient, dedicated syntax. Unlike the `hash!` datatype, a map is not a series, so does not have a concept of offset or positions. Conceptually, the `map!` datatype lies between the `hash!` and `object!` datatypes.
 
 == Literal syntax
+
 ----
 #(<key> <value>...)
 
 <key>   : hashed key, accepted types are: scalar!, all-word!, any-string!
 <value> : any-type! value
 ----
+
 == Creation syntax
+
 ----
 make map! <spec>
 
 <spec> : block of key/value pairs or an integer value
 ----
+
 If the _spec_ argument is an integer, an empty `map!` is created with a pre-allocated number of slots (usually in order to populate the map dynamically).
 
-Notes:
-
+[NOTE]
+====
 * the map body or the spec block have to contain an *even* number of elements, otherwise an error will be generated. 
 * values are not *reduced*, so construction syntax is required for some special values, like `logic!`.
+====
 
 Examples:
+
 ----
 #(a: 1 b: 2)
 == #(
@@ -41,20 +47,23 @@ make map! [a 1 'b 2 "c" 3]
     "c" 3
 )
 ----
+
 If the key is of *any-word!* type, the key type is converted to *set-word!* in the map, in order to make the map content look more like pairs of keys with value assigned. Though, in order to access word keys, there is no requirement to provide a set-word, for practical reasons (easier construction, especially in paths), simple words can be used. Similarly, `keys-of` reflector (described in Reflection section below), will return words instead of set-words, as it simplifies further processing (especially matching operations are easier with words rather than set-words).
 
-Notes:
-
+[NOTE]
+====
 * Like `hash!` and `block!`, `map!` is **case-preserving**, and **case-insensitive for lookup** by default.
 * If a `none` value is specified as value, the key will not be created (see "Deleting keys" section).
 * All the keys are deep copied on creation of the map.
 * Series! values are not copied on creation of the map, the choice is left to the user (this optimizes resources for the common use-case).
+====
 
 Another way to create a new map is to use the `copy` action on an existing one.
 
 == Retrieving values
 
 Using paths:
+
 ----
 <map>/<key>
 get '<map>/<key>
@@ -64,17 +73,21 @@ get '<map>/<key>
 ----
 
 Using selecting action:
+
 ---- 
 select <map> <key>
 
 <map> : map value
 <key> : any valid key type
 ----
+
 All these read accesses are case-insensitive. In order to have a case-sensitive lookup, the `/case` refinement needs to be used where available:
+
 ----
 get/case '<map>/<key>
 select/case <map> <key>
 ----
+
 Trying to access a key not defined in a map will return a `none` value.
 
 Examples:
@@ -94,6 +107,7 @@ select/case m 'ab
 == Changing keys and values
 
 Using paths:
+
 ----
 <map>/<key>: <value>
 set '<map>/<key> <value>
@@ -104,13 +118,16 @@ set '<map>/<key> <value>
 ----
 
 Using modifying action:
+
 ---- 
 put <map> <key> <value>
 
 <map> : map value
 <key> : any valid key value to select a value in the map
 ----
+
 Making bulk changes:
+
 ----
 extend <map> <spec>
 
@@ -119,6 +136,7 @@ extend <map> <spec>
 ----
 
 All these write accesses are case-insensitive. In order to have a case-sensitive lookup, the `/case` refinement needs to be used where available:
+
 ----
 set/case '<map>/<key> <value>
 put/case <map> <key> <value>
@@ -127,12 +145,14 @@ extend/case <map> <spec>
 
 `extend` native can accept many keys at the same time, so it is convenient for bulk changes.
 
-Notes:
-
+[NOTE]
+====
 * setting a key that did not exist previously in the map, **will simply create it**.
 * adding an existing key will change the key value and not add a new one (case-insensitive matching by default).
+====
 
 Examples:
+
 ----
 m: #(Ab: 2 aB: 5 ab: 10)
 m/ab: 3
@@ -180,6 +200,7 @@ m
 In order to delete a key/value pair from a map, you simply set the key to `none` value using one of the available ways.
 
 Example:
+
 ----
 m: #(a: 1 b 2 "c" 3 d: 99)
 m
@@ -201,6 +222,7 @@ m
 NOTE: Construction syntax is required in the above example in order to pass a `none!` value and not a `word!` value (just one way to construct the spec block needed there).
 
 It is also possible to delete all keys at same time using `clear` action:
+
 ----
 clear #(a 1 b 2 c 3)
 == #()

--- a/en/preprocessor.adoc
+++ b/en/preprocessor.adoc
@@ -23,7 +23,7 @@ Directives are denoted by specific `issue!` values (starting with a `#` symbol).
 
 When a directive is processed, it is replaced by the resulting value it returns (some directives do not return anything, so they are just removed). That is how transformations of source code is achieved.
 
-Notes: Red/System has its own http://static.red-lang.org/red-system-specs-light.html#section-16[preprocessor], which is similar, but low-level and applied to the source code in text form.
+NOTE: Red/System has its own http://static.red-lang.org/red-system-specs-light.html#section-16[preprocessor], which is similar, but low-level and applied to the source code in text form.
 
 === Config object
 
@@ -33,15 +33,14 @@ In conditional expressions and in macros, an implicit `config` object is provide
     
     #if config/OS = 'Windows [#include %windows.red]
 
-NOTE:
- when using the preprocessor at runtime (from Red's interpreter), the `config` object is also available, and will reflect the options used for compiling the Red executable currently used to run the code.
+NOTE: When using the preprocessor at runtime (from Red's interpreter), the `config` object is also available, and will reflect the options used for compiling the Red executable currently used to run the code.
 
 === Execution context
 
 All the expressions used in directives are bound to a dedicated context to avoid leaking words in global context, causing unwanted side-effects. That context is extended with every set-word used in conditional expressions, macros and `#do` directives.
 
-Tips:
-
+[TIP]
+====
 * It is possible to print out the content of that hidden context using the following expression:
         
         #do [probe self]
@@ -49,10 +48,11 @@ Tips:
 * When used at runtime, the hidden context can also be accessed directly using:
         
         probe preprocessor/exec
+====
 
 === Implementation note
 
-Currently, expressions in directives used at compile-time are evaluated using Rebol2 interpreter, as it is running the toolchain code. This is temporary and should be switched to a Red evaluator as soon as possible. In the meantime, ensure that  your expressions and macros code can be run with Red too, for compatibility with Red interpreter at run-time (and at compile-time in the future).
+Currently, expressions in directives used at compile-time are evaluated using Rebol2 interpreter, as it is running the toolchain code. This is temporary and should be switched to a Red evaluator as soon as possible. In the meantime, ensure that your expressions and macros code can be run with Red too, for compatibility with Red interpreter at run-time (and at compile-time in the future).
 
 == Macros
 
@@ -75,20 +75,25 @@ After defining such macro, each time the `name` word is encountered in the sourc
 . Replace the macro call and its arguments with the last value of the function.
 . Resume preprocessing from the replaced value (allowing recursive macro evaluation).
 
-NOTE: specifying types for the arguments is not currently supported.
+NOTE: Specifying types for the arguments is not currently supported.
 
 *Examples:*
+
 ----
 Red []
 #macro make-KB: func [n][n * 1024]
 print make-KB 64
 ----  
+
 will result in:    
+
 ----
 Red []
 print 65536
 ----
+
 Calling other macros, from within a macro:
+
 ----
 Red []
 #macro make-KB: func [n][n * 1024]
@@ -96,11 +101,14 @@ Red []
 
 print make-MB 1
 ----  
+
 will result in:    
+
 ----  
 Red []
 print 1048576
 ----
+
 === Pattern-matching macros
 
 Instead of matching a word and fetching argument, this type of macros matches a pattern provided as a Parse dialect rule or keyword. Like for the named macros, the returned value is used as replacement for the matched pattern.
@@ -108,9 +116,11 @@ Instead of matching a word and fetching argument, this type of macros matches a 
 Though, there is also a lower-level version of this type of macros, which is triggered by the usage of the `[manual]` attribute. In such case, there are no implicit actions, but full control is given to the user.  No automatic replacement takes place, it is up to the macro function to apply the desired transformations and set the resuming point of the processing.
 
 The typical form of pattern-matching macros is:
+
 ----
  #macro <rule> func [<attribute> start end /local word1 word2...][...code...]
 ----
+
 The `<rule>` part can be:
 
 * a `lit-word!` value: for matching a specfic word.
@@ -122,18 +132,23 @@ The `<rule>` part can be:
 `<attribute>` can be `[manual]`, which triggers the low-level manual mode for the macro.
 
 *Examples:*
+
 ----
 Red []
 
 #macro integer! func [s e][s/1 + 1]
 print 1 + 2
 ----
+
 will result in:
+
 ----
 Red []
 print 2 + 3 
 ----
+
 Using *manual* mode, the same macro would be written as:
+
 ----
 Red []
 
@@ -142,6 +157,7 @@ print 1 + 2
 ----
   
 Using a block rule to create a variable-arity function:
+
 ----
 Red []
 #macro ['max some [integer!]] func [s e][
@@ -149,43 +165,55 @@ Red []
 ]
 print max 4 2 3 8 1
 ----
+
 will result in:
+
 ----
 Red []
 print 8 
 ----
+
 == Directives 
 
 === #if 
 
 *Syntax*
+
 ----
 #if <expr> [<body>]
 
 <expr> : expression whose last value will be used as a condition.
 <body> : code to be included if <expr> is true.
 ----
+
 *Description*
 
 Include a block of code if the conditional expression is true. If the `<body>` block is included, it will be also passed to the preprocessor.
 
 *Examples*
+
 ----
 Red []
 
 #if config/OS = 'Windows [print "OS is Windows"]
 ----
+
 will result in the following code if run on Windows:
+
 ----
 Red []
 
 print "OS is Windows"
 ----
+
 and otherwise, will result in just:
+
 ----
 Red []
 ----
+
 It is also possible to define your own words using `#do` directive, which can be used in conditional expressions later:
+
 ----
 Red []
 
@@ -193,15 +221,19 @@ Red []
 
 #if debug? [print "running in debug mode"]
 ----
+
 will result in:
+
 ----
 Red []
 
 print "running in debug mode"
 ----
+
 === #either 
 
 *Syntax*
+
 ----
 #either <expr> [<true>][<false>]
 
@@ -209,31 +241,39 @@ print "running in debug mode"
 <true>  : code to be included if <expr> is true.
 <false> : code to be included if <expr> is false.
 ----
+
 *Description*
 
 Choose a block of code to include depending on a conditional expression. The included block will be also passed to the preprocessor.
 
 *Example*
+
 ----
 Red []
 
 print #either config/OS = 'Windows ["Windows"]["Unix"]
 ----
+
 will result in the following code if run on Windows:
+
 ----
 Red []
 
 print "Windows"
 ----
+
 and otherwise, will result in:
+
 ----
 Red []
 
 print "Unix"
 ----
+
 === #switch 
 
 *Syntax*
+
 ----
 #switch <expr> [<value1> [<case1>] <value2> [<case2>] ...]
 #switch <expr> [<value1> [<case1>] <value2> [<case2>] ... #default [<default>]]
@@ -242,11 +282,13 @@ print "Unix"
 <caseN>   : code to be included if last tested value matched.
 <default> : code to be included if no other value matched.
 ----
+
 *Description*
 
 Choose a block of code to include among several choices, depending on a value. The included block will be also passed to the preprocessor.
 
 *Example*
+
 ----
 Red []
 
@@ -256,26 +298,32 @@ print #switch config/OS [
     macOS   ["macOS"]
 ]
 ----   
+
 will result in the following code if run on Windows:
+
 ----
 Red []
 
 print "Windows"
 ----
+
 === #case 
 
 *Syntax*
+
 ----
 #case [<expr1> [<case1>] <expr2> [<case2>] ...]
 
 <exprN> : conditional expression.
 <caseN> : code to be included if last conditional expression was true.
 ---- 
+
 *Description*
 
 Choose a block of code to include among several choices, depending on a value. The included block will be also passed to the preprocessor.
 
 *Example*
+
 ----
 Red []
 
@@ -287,20 +335,25 @@ print #case [
     level >= 4 ["Hard"]
 ]
 ----  
+
 will result in:
+
 ----
 Red []
 
 print "Medium"
 ----
+
 === #include 
 
 *Syntax*
+
 ----
 #include <file>
 
 <file> : Red file to be included (file!).
 ----  
+
 *Description*
 
 When evaluated at compile-time, read and include the argument file contents at the current position. The file can contain a path, absolute or relative to the current script. When run by the Red interpreter, this directive is just replaced by a `do`, and no file inclusion occurs.
@@ -308,17 +361,20 @@ When evaluated at compile-time, read and include the argument file contents at t
 === #do 
 
 *Syntax*
+
 ----
 #do [<body>]
 #do keep [<body>]
 
 <body> : any Red code.
 ----    
+
 *Description*
 
 Evaluate the body block in the hidden execution context. If `keep` is used, replace the directive and argument with the result of evaluating `body`.
 
 *Example*
+
 ----
 Red []
 
@@ -328,7 +384,9 @@ print ["2 + 3 =" #do keep [2 + 3]]
     
 #if a < 0 [print "negative"]
 ----    
+
 will result in:
+
 ----
 Red []
 
@@ -338,6 +396,7 @@ print ["2 + 3 =" 5]
 === #macro
 
 *Syntax*
+
 ----
 #macro <name> func <spec> <body>
 #macro <pattern> func <spec> <body>
@@ -365,19 +424,24 @@ A pattern-matching macro accepts:
 * a lit-word: specifies a specific literal word to match.
 
 *Examples*
+
 ----
 Red []
 #macro pow2: func [n][to integer! n ** 2]
 print pow2 10
 print pow2 3 + pow2 4 = pow2 5
 ----
+
 will result in:
+
 ----
 Red []
 print 100
 print 9 + 16 = 25
 ----   
+
 Pattern-matching macro example:
+
 ----
 Red []
 #macro [number! '+ number! '= number!] func [s e][
@@ -386,12 +450,16 @@ Red []
 
 print 9 + 16 = 25
 ----
+
 will result in:
+
 ----
 Red []
 print true
 ----
+
 A pattern-matching macro in manual mode:
+
 ----
 Red []
 #macro ['sqrt number!] func [[manual] s e][
@@ -408,7 +476,9 @@ Red []
 print sqrt 9
 print sqrt -4
 ----
+
 will result in:
+
 ----
 *** SQRT Error: no negative number allowed 
 *** At: sqrt -4
@@ -418,16 +488,19 @@ will result in:
 === #local 
 
 *Syntax*
+
 ----
 #local [<body>]
 
 <body> : arbitrary Red code containing local macros definitions.
 ----    
+
 *Description*
 
 Create a local context for macros. All macros defined in that context will be discarded on exit. Therefore, the local macros also need to be locally applied. This directive can be used recursively (`#local` is a valid directive in `<body>`).
 
 *Example*
+
 ----
 Red []
 print 1.0
@@ -437,19 +510,24 @@ print 1.0
 ]
 print 2.0
 ----
+
 will result in:
+
 ----
 Red []
 print 1.0
 print [1 3 124]
 print 2.0
 ----
+
 === #reset 
 
 *Syntax*
+
 ----
 #reset
 ---- 
+
 *Description*
 
 Reset the hidden context, emptying it from all previously defined words and removing all previously defined macros.
@@ -457,9 +535,11 @@ Reset the hidden context, emptying it from all previously defined words and remo
 === #process
 
 *Syntax*
+
 ----
 #process [on | off]
 ---- 
+
 *Description*
 
 Enable or disable the preprocessor (it is enabled by default). This is an escape mechanism to avoid processing parts of Red files where directives are used literally and not meant for the preprocessor (for example, if used in a dialect with a different meaning).
@@ -467,6 +547,7 @@ Enable or disable the preprocessor (it is enabled by default). This is an escape
 Implementation constraint: when enabling the preprocessor again after disabling it earlier, the `#process off` directive needs to be at same (or higher) level of nesting in the code.
 
 *Example*
+
 ----
 Red []
 
@@ -475,19 +556,24 @@ print "Conditional directives:"
 foreach d [#if #either #switch #case][probe d]
 #process on
 ----    
+
 will result in:
+
 ----
 Red []
 
 print "Conditional directives:"
 foreach d [#if #either #switch #case][probe d]
 ----
+
 === #trace 
 
 *Syntax*
+
 ----
 #trace [on | off]
 ----  
+
 *Description*
 
 Enable or disable the debugging output of evaluated expressions and macros on screen. There are no specific constraints on where this directive can be used in the Red sources.
@@ -500,21 +586,26 @@ The Red preprocessor can also work at run-time, in order to be able to evaluate 
 === expand-directives 
 
 *Syntax*
+
 ----
 expand-directives [<body>]
 expand-directives/clean [<body>]
 
 <body> : arbitrary Red code containing preprocessor directives.
 ----
+
 *Description*
 
 Invoke the preprocessor on a block value. The argument block will be modified and used as returned value. If `/clean` refinement is used, the preprocessor state is reset, so all the macros previously defined are erased.
 
 *Example*
+
 ----
 expand-directives [print #either config/OS = 'Windows ["Windows"]["Unix"]]
 ----
+
 will return on Windows platform:
+
 ----
 [print "Windows"]
 ----

--- a/en/reactivity.adoc
+++ b/en/reactivity.adoc
@@ -22,11 +22,12 @@ Reactions are run asynchronously, when a source field's value is changed. The re
 
 Only the source objects in a reactive expression need to be a reactor. The target can be a simple object. If the target is also a reactor, reactions are chained and a graph of relations is constructed implicitly.
 
-Notes:
-
+[NOTE]
+====
 * Red's reactive support could be extended in the future to support a "pull" model.
 * This is not a https://en.wikipedia.org/wiki/Functional_reactive_programming[FRP] framework, though event streams could be supported in the future.
 * The Red/View GUI engine relies on _face!_ objects in order to operate on graphic objects. Faces are reactors, and they can be used for setting reactive relations between faces or with non-reactor objects.
+====
 
 === Glossary 
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -28,6 +28,7 @@ Lexical conventions:
 
 
 == Header
+
 ----
 magic="REDBIN" (6), version=1 (1), flags (1), length (4), size (4)
 
@@ -40,9 +41,11 @@ flags (option is enabled if bit is set):
 length : number of root records to load.
 size   : size of records payload in bytes.
 ----
+
 If compression is applied, the data following the header is the payload to be compressed. Compression algorithm choice is implementation-dependent.
 
 == Symbol Table
+
 The symbol table immediately follows the header data. It is optional and should only be used if words are present in the rest of the Redbin payload. The symbol table has two sections:
 
 * a table of offsets to string representation of each symbol
@@ -64,6 +67,7 @@ After the Symbol Table, Red values are stored as records in sequence with no spe
 == Records definitions
 
 Each records starts with a 32-bit `header` field defined as:
+
 ****
  * bit31    : new-line flag
  * bit30    : no-values flag (for contexts)
@@ -74,18 +78,22 @@ Each records starts with a 32-bit `header` field defined as:
  * bit15-8  : unit (used for encoding elements size in a series buffer)
  * bit7-0   : type
 ****
+
 Here follows the description of each individual record:
 
 === Padding anchor:padding[] 
+
 ----
 Default: header (4)
 Compact: n/a
 
 header/type=0
 ----
+
 This empty type slot is used to properly align 64-bit values.
 
 === Datatype! anchor:datatype[] 
+
 ----
 Default: header (4), value (4)
 Compact: TBD
@@ -94,6 +102,7 @@ header/type=1
 ----
 
 === Unset! anchor:unset[] 
+
 ----
 Default: header (4)
 Compact: TBD
@@ -102,6 +111,7 @@ header/type=2
 ----
 
 === None! anchor:none[] 
+
 ----
 Default: header (4)
 Compact: TBD
@@ -110,6 +120,7 @@ header/type=3
 ----
 
 === Logic! anchor:logic[] 
+
 ----
 Default: header (4), value=0|1 (4)
 Compact: TBD
@@ -118,24 +129,29 @@ header/type=4
 ----
 
 === Block! anchor:block[] 
+
 ----
 Default: header (4), head (4), length (4), ...
 Compact: TBD
 
 header/type=5
 ----
+
 The `head` field indicates the offset of the block reference, using a zero-based integer. The `length` field contains the number of values to be stored in the block. The block values simply follow the block definition, no separator or end delimiter is required.
 
 === Paren! anchor:paren[] 
+
 ----
 Default: header (4), head (4), length (4), ...
 Compact: TBD
 
 header/type=6
 ----
+
 Same encoding rules as `block!`.
 
 === String! anchor:string[] 
+
 ----
 Default: header (4), head (4), length (4), data (unit*length) [, padding (1-3)]
 Compact: TBD
@@ -143,9 +159,11 @@ Compact: TBD
 header/type=7
 header/unit=1|2|4
 ----
+
 `head` field has same meaning as for blocks. The `unit` sub-field indicates the encoding format of the string, only values of 1, 2 and 4 are valid. The `length` field contains the number of codepoints to be stored in the string, up to 16777215 codepoints (2^24 - 1) are supported. The string is encoded in UCS-1, UCS-2 or UCS-4 format. No NUL character is present, nor accounted for in the `length` field. An optional tail padding of 1 to 3 NUL bytes can be present to align the end of the `string!` record with a 32-bit boundary.
 
 === File! anchor:file[] 
+
 ----
 Default: header (4), head (4), length (4), data (unit*length)
 Compact: TBD
@@ -153,18 +171,22 @@ Compact: TBD
 header/type=8
 header/unit=1|2|4
 ----
+
 Same encoding rules as `string!`.
 
 === Url! anchor:url[] 
+
 ----
 Default: header (4), head (4), length (4), data (unit*length)
 Compact: TBD
 
 header/type=9
 ----
+
 Same encoding rules as `string!`.
 
 === Char! anchor:char[] 
+
 ----
 Default: header (4), value (4)
 Compact: TBD
@@ -173,6 +195,7 @@ header/type=10
 ----
 
 === Integer! anchor:integer[] 
+
 ----
 Default: header (4), value (4)
 Compact: TBD
@@ -181,15 +204,18 @@ header/type=11
 ----
 
 === Float! anchor:float[] 
+
 ----
 Default: [padding=0 (4),] header (4), value (8)
 Compact: TBD
 
 header/type=12
+
 ----
 The optional padding field is added to properly align the `value` field offset to a 64-bit value.
 
 === Context! anchor:context[] 
+
 ----
 Default: header (4), length (4), symbol1 (4), symbol2 (4),..., value1 [any-type!], value2 [any-type!], ...
 Compact: TBD
@@ -199,9 +225,11 @@ header/no-values=0|1
 header/stack?=0|1
 header/self?=0|1
 ----
+
 Contexts are Red values used internally by some datatypes like `function!`, `object!` and derivative types. A context contains two consecutive tables, the first one is the list of word entries in the context represented as symbol references, the second is the associated values for each of the symbols in the first table. `length` field indicates the number of entries in the context. Context records can only exist at root level, they cannot be nested. If `no-values` flag is set, it means that there are no values following the symbols (empty context). If `stack?` flag is set, then the values are allocated on the stack instead of the heap memory. The `self?` flag is used to indicate that the context is able to handle a self-referencing word (`self` in objects).
 
 === Word! anchor:word[] 
+
 ----
 Default: header (4), symbol (4), context (4), index (4)
 Compact: TBD
@@ -209,20 +237,24 @@ Compact: TBD
 header/type=15
 header/set?=0|1
 ----
+
 The `context` field is an offset from the beginning of the records section in the Redbin file referring to a `context!` value. The context needs to be located before the word record in the Redbin records list. If `context` equals `-1`, it refers to global context.
 
 If the `set?` field is defined, this record is followed by an `any-value!` record, and the word will need to be set to that value (in the right context) by the decoder. This forms a name/value couple allowing to encode words' values in an adhoc way, when providing a sequence of values for a given context is too expensive (mostly for name/value couples in global context).
 
 === Set-word! anchor:set-word[] 
+
 ----
 Default: header (4), symbol (4), context (4), index (4)
 Compact: TBD
 
 header/type=16
 ----
+
 Same as `word!`.
 
 === Lit-word! anchor:lit-word[] 
+
 ----
 Default: header (4), symbol (4), context (4), index (4)
 Compact: TBD
@@ -232,6 +264,7 @@ header/type=17
 Same as `word!`.
 
 === Get-word! anchor:get-word[] 
+
 ----
 Default: header (4), symbol (4), context (4), index (4)
 Compact: TBD
@@ -241,15 +274,18 @@ header/type=18
 Same as `word!`.
 
 === Refinement! anchor:refinement[] 
+
 ----
 Default: header (4), symbol (4), context (4), index (4)
 Compact: TBD
 
 header/type=19
 ----
+
 Same as `word!`.
 
 === Issue! anchor:issue[] 
+
 ----
 Default: header (4), symbol (4)
 Compact: TBD
@@ -258,35 +294,42 @@ header/type=20
 ----
 
 === Native! anchor:native[] 
+
 ----
 Default: header (4), ID (4), spec [block!]
 Compact: TBD
 
 header/type=21
 ----
+
 `ID` is an offset into the internal `natives/table` jump table.
 
 
 === Action! anchor:action[] 
+
 ----
 Default: header (4), ID (4), spec [block!]
 Compact: TBD
 
 header/type=22
 ----
+
 `ID` is an offset into the internal `actions/table` jump table.
 
 === Op! anchor:op[] 
+
 ----
 Default: header (4), symbol (4), 
 Compact: TBD
 
 header/type=23
 ----
+
 `symbol` represents the action, native or function name (only from global context) used as the source for that `op!` value. 
 
 
 === Function! anchor:function[] 
+
 ----
 Default: header (4), context [context!], spec [block!], body [block!], args [block!], obj-ctx [context!]
 Compact: TBD
@@ -295,51 +338,62 @@ header/type=24
 ----
 
 === Path! anchor:path[] 
+
 ----
 Default: header (4), head (4), length (4), ...
 Compact: TBD
 
 header/type=25
 ----
+
 Same encoding rules as `block!`.
 
 === Lit-path! anchor:lit-path[] 
+
 ----
 Default: header (4), head (4), length (4), ...
 Compact: TBD
 
 header/type=26
 ----
+
 Same encoding rules as `block!`.
 
 === Set-path! anchor:set-path[] 
+
 ----
 Default: header (4), head (4), length (4), ...
 Compact: TBD
 
 header/type=27
 ----
+
 Same encoding rules as `block!`.
 
 === Get-path! anchor:get-path[] 
+
 ----
 Default: header (4), head (4), length (4), ...
 Compact: TBD
 
 header/type=28
 ----
+
 Same encoding rules as `block!`.
 
 === Bitset! anchor:bitset[] 
+
 ----
 Default: header (4), length (4), bits (length)
 Compact: TBD
 
 header/type=30
 ----
+
 The `length` fields indicates the number of bits stored, rounded to the upper multiple of 8. The bits are memory dumps of the `bitset!` series buffer. Byte order is preserved. `bits` field needs to be padded with enough NUL bytes to keep the next record 32-bit aligned.
 
 === Point! anchor:point[] 
+
 ----
 Default: header (4), x (4), y (4), z (4)
 Compact: TBD
@@ -348,15 +402,18 @@ header/type=31
 ----
 
 === Object! anchor:object[] 
+
 ----
 Default: header (4), context [reference!], class-id (4), on-set-idx (4), on-set-arity (4)
 Compact: TBD
 
 header/type=32
 ----
+
 The `on-set-idx` field indicates the offset of the `on-change*` in the context values table. The `on-set-arity` stores the arity of that function.
 
 === Typeset! anchor:typeset[] 
+
 ----
 Default: header (4), array1 (4), array2 (4), array3 (4)
 Compact: TBD
@@ -365,6 +422,7 @@ header/type=33
 ----
 
 === Error! anchor:error[] 
+
 ----
 Default: header (4), context [reference!]
 Compact: TBD
@@ -373,15 +431,18 @@ header/type=34
 ----
 
 === Vector! anchor:vector[] 
+
 ----
 Default: header (4), head (4), length (4), values (unit*length)
 Compact: TBD
 
 header/type=35
 ----
+
 `unit` indicates the size of the vector element type size: 1, 2, 4 or 8 bytes. The `values` field holds the list of values. `values` needs to be padded with NUL bytes to align the next record to a 32-bit boundary (if `unit` is equal to 1 or 2).
 
 === Pair! anchor:pair[] 
+
 ----
 Default: header (4), x (4), y (4)
 Compact: TBD
@@ -390,15 +451,18 @@ header/type=37
 ----
 
 === Percent! anchor:percent[] 
+
 ----
 Default: [padding=0 (4),] header (4), value (8)
 Compact: TBD
 
 header/type=38
 ----
+
 Percent value is stored as a 64-bit float. The optional padding field is added to properly align the `value` field offset to a 64-bit value.
 
 === Tuple! anchor:tuple[] 
+
 ----
 Default: header (4), array1 (4), array2 (4), array3 (4)
 Compact: TBD
@@ -407,33 +471,40 @@ header/type=39
 ----
 
 === Map! anchor:map[] 
+
 ----
 Default: header (4), length (4), ...
 Compact: TBD
 
 header/type=40
 ----
+
 The `length` field contains the number of elements (keys + values) to be stored in the map. The map elements simply follow the length definition, no separator or end delimiter is required.
 
 === Binary! anchor:binary[] 
+
 ----
 Default: header (4), head (4), length (4), ...
 Compact: TBD
 
 header/type=41
 ----
+
 Same encoding rules as `block!`.
 
 === Time! anchor:time[] 
+
 ----
 Default: [padding=0 (4),] header (4), value (8)
 Compact: TBD
 
 header/type=43
 ----
+
 Time value is stored as a 64-bit float. The optional padding field is added to properly align the `value` field offset to a 64-bit value.
 
 === Tag! anchor:tag[] 
+
 ----
 Default: header (4), head (4), length (4), data (unit*length)
 Compact: TBD
@@ -441,9 +512,11 @@ Compact: TBD
 header/type=44
 header/unit=1|2|4
 ----
+
 Same encoding rules as `string!`.
 
 === Email! anchor:email[] 
+
 ----
 Default: header (4), head (4), length (4), data (unit*length)
 Compact: TBD
@@ -451,22 +524,27 @@ Compact: TBD
 header/type=45
 header/unit=1|2|4
 ----
+
 Same encoding rules as `string!`.
 
 === Date! anchor:date[] 
+
 ----
 Default: header (4), date (4), time (8)
 Compact: TBD
 
 header/type=47
 ----
+
 Date is packed into a 32-bit integer (same as in `red-date!`). Time value is stored as a 64-bit float.
 
 === Reference! anchor:reference[] 
-----
- Default: header (4), count (4), index1 (4), index2 (4), ...
- Compact: TBD
 
- header/type=255
 ----
+Default: header (4), count (4), index1 (4), index2 (4), ...
+Compact: TBD
+
+header/type=255
+----
+
 This special record type stores a reference to an already loaded value of type `any-block!` or `object!`. This makes it possible to store cycles in Redbin. The reference is created from a path into the loaded values (assuming that the root values are stored in a block). Each `index` field points to the series or object value to go into, until the last one is reached, pointing to the value to refer to. The `count` field indicates the number of indexes to go through. If one of the indexes has to be applied to an object, it refers to the corresponding object's field (0 => 1st field, 1 => 2nd field,...). All indexes are zero-based.

--- a/en/style-guide.adoc
+++ b/en/style-guide.adoc
@@ -27,6 +27,7 @@ All the contributed Red files to `red/red` repo should contain the following fie
 Each time you go to a new line after opening a block or a parenthesis, you should indent by one tab.
 
 *Correct*
+
 ----
  func [
      arg1
@@ -37,7 +38,9 @@ Each time you go to a new line after opening a block or a parenthesis, you shoul
      ...
  ]
 ----
+
 Incorrect
+
 ---- 
  func [
  arg1				;-- missing indentation!
@@ -69,6 +72,7 @@ Contiguous blocks do not require a whitespace between the end of one and start o
  ]
  
 However, it is acceptable to use whitespaces in-between nested blocks:
+
 ----
  array: [[] [] [] []]
  list:  [ [] [] [] [] ]
@@ -85,6 +89,7 @@ For expressions containing small blocks, they are usually opened and closed on t
 If the line is too long, the block should be wrapped over several lines with one level of indentation:
 
 *Correct*
+
 ----
  b: either a = 1 [
      a + 1
@@ -94,13 +99,16 @@ If the line is too long, the block should be wrapped over several lines with one
 ----
 
 Incorrect
+
 ----
  b: either a = 1 
      [a + 1][123 + length? mold a]
 ----
-_That style is wrong because it breaks the ability to copy/paste code to the Red console (`either ` will be evaluated before the block arguments are detected)._
+
+_That style is wrong because it breaks the ability to copy/paste code to the Red console (`either` will be evaluated before the block arguments are detected)._
 
 If the first block is small enough and can fit on the same line, then only the subsequent blocks are wrapped over several lines:
+
 ----
  print either a = 1 ["hello"][
      append mold a "this is a very long expression"
@@ -119,6 +127,7 @@ If the first block is small enough and can fit on the same line, then only the s
 Names made of multiple words are separated with a dash `-` character. Use a two-words name only when a fitting single-word cannot be found or would be too confusing with already used ones. Variable names made of more than two words should only be used in rare cases. Using single-words as much as possible makes the code horizontally much more compact, improving readability greatly. Avoid useless verbosity.
 
 *Correct*
+
 ----
  code: 123456
  name: "John"
@@ -129,6 +138,7 @@ Names made of multiple words are separated with a dash `-` character. Use a two-
 ----
 
 Incorrect
+
 ----
  code_for_article: 123456
  Mytable: [2 6 8 4 3]
@@ -140,6 +150,7 @@ Incorrect
 *Function names* should strive to be single-word _verbs_, in order to express an action, though two or three words names are often necessary. More than three words should be avoided as much as possible. Variable naming conventions also apply to function names. A noun or an adjective followed by a question mark is also accepted. Often, it denotes that the return value is of `logic!` type, but this is not a strict rule, as it is handy to form single-word action names for retrieving a property (e.g. `length?`, `index?`). When forming function names with two or more words, always put the verb in the first position. If names are picked carefully for variables and function names, the code becomes almost self-documented, often reducing the need for comments.
 
 *Correct*
+
 ----
  make:   func [...
  reduce: func [...
@@ -148,6 +159,7 @@ Incorrect
 ----
 
 Incorrect
+
 ----
  length:    func [...
  future:    func [...
@@ -198,7 +210,7 @@ All variable and function names should be lowercase by default, unless there is 
 
 == Macros (Red/System) anchor:macros-redsystem[]
 
-Apply the same naming conventions for picking up Red/System macros names. Macros generally use uppercase for names, as a way to visually distinguish them easily from the rest of the code (unless the intention is explicitely to make it look like regular code, like pseudo-custom datatype definitions). When multiple words are used, they are separated by an underscore `_` character to increase even more the difference with regular code.
+Apply the same naming conventions for picking up Red/System macros names. Macros generally use uppercase for names, as a way to visually distinguish them easily from the rest of the code (unless the intention is explicit to make it look like regular code, like pseudo-custom datatype definitions). When multiple words are used, they are separated by an underscore `_` character to increase even more the difference with regular code.
 
 _(TBD: extract all single-word names used in the Red codebase as examples)_
 
@@ -207,6 +219,7 @@ _(TBD: extract all single-word names used in the Red codebase as examples)_
 The general rule is to keep the spec block on a single line. The body block can be on the same line or over several lines. In case of Red/System, as the spec blocks tend to be longer, most functions spec blocks are wrapped over several lines, so, for sake of visual consistency, often even small spec block are wrapped.
 
 *Correct*
+
 ----
  do-nothing: func [][]
  increment: func [n [integer!]][n + 1]
@@ -221,7 +234,9 @@ The general rule is to keep the spec block on a single line. The body block can 
      n + 1
  ]
 ----
+
 Incorrect
+
 ----
  do-nothing: func [
  ][
@@ -243,6 +258,7 @@ When the spec block is too long, it should be wrapped over several lines. When w
 When wrapping the spec block over several lines, it is recommended to align the datatype definitions for consecutive arguments, on the same column for easier reading. Such alignment is preferably done using tabs (if you strictly follow these coding style rules) or else, using spaces.
 
 *Correct*
+
 ----
  make-world: func [
      earth	 [word!]
@@ -260,7 +276,9 @@ When wrapping the spec block over several lines, it is recommended to align the 
      ...
  ]
 ----
+
 Incorrect
+
 ----
  make-world: func [
   	[throw] earth [word!]		;-- attributes block not on its own line
@@ -282,6 +300,7 @@ Incorrect
 For docstrings, the main one (describing the function) should be on its own line if the spec block is wrapped. The argument and refinement docstrings should be on the same line as the item they are describing. Docstrings start with a capital letter and do not require an ending dot (it's added automatically when printed on screen by `help` function).
 
 *Correct*
+
 ----
  increment: func ["Add 1 to the argument value" n][n + 1]
 
@@ -302,7 +321,9 @@ For docstrings, the main one (describing the function) should be on its own line
 	...
  ]
 ----
+
 Incorrect
+
 ----
  make-world: func ["Build a new World"	;-- should be on a newline
      earth	[word!]		"1st element"
@@ -328,6 +349,7 @@ Incorrect
 Arguments are following the function call on the same line. If the line becomes too long, arguments can be wrapped over several lines (one argument per line) with an indentation.
 
 *Correct*
+
 ----
  foo arg1 arg2 arg3 arg4 arg5
 
@@ -338,7 +360,9 @@ Arguments are following the function call on the same line. If the line becomes 
      argument4
      argument5
 ----
+
 Incorrect
+
 ----
  foo arg1 arg2 arg3
      arg4 arg5
@@ -356,6 +380,7 @@ Incorrect
 ----
 
 For long expressions with many nested parts, spotting the bounds of each expression can be sometimes difficult. Using parenthesis for grouping a nested call with its arguments is acceptable (but not mandatory).
+
 ----
  head insert (copy/part [1 2 3 4] 2) (length? mold (2 + index? find "Hello" #"o"))
 

--- a/en/vid.adoc
+++ b/en/vid.adoc
@@ -44,11 +44,13 @@ NOTE: `react` keyword can also be used at the container settings level in additi
 === title
 
 *Syntax*
+
 ----
 title <text>
 
 <text> : title text (string!).
 ----
+
 *Description*
 
 Sets the title text of the container face.
@@ -57,11 +59,13 @@ Sets the title text of the container face.
 === size 
 
 *Syntax*
+
 ----
 size <value>
 
 <value> : width and height in pixels (pair!).
 ----
+
 *Description*
 
 Sets the size of the container face. If the size is not explicitly provided, the container's size is automatically calculated to fit its content.
@@ -70,11 +74,13 @@ Sets the size of the container face. If the size is not explicitly provided, the
 === backdrop 
 
 *Syntax*
+
 ----
 backdrop <color>
 
 <color> : name or value of a color (word! tuple! issue!).
 ----
+
 *Description*
 
 Sets the background color of the container face.
@@ -109,11 +115,13 @@ image::below.png[below,align="center"]
 === across 
 
 *Syntax*
+
 ----
 across <alignment>
 
 <alignment> : (optional) possible values: top | middle | bottom.
 ----
+
 *Description*
 
 Sets the layout direction to horizontal, from left to right. An alignment modifier can be optionally provided to change the default (`top`) alignment of faces in the row.
@@ -122,11 +130,13 @@ Sets the layout direction to horizontal, from left to right. An alignment modifi
 === below 
 
 *Syntax*
+
 ----
 below <alignment>
 
 <alignment> : (optional) possible values: left | center | right.
 ----
+
 *Description*
 
 Sets the layout direction to vertical, from top to bottom. An alignment modifier can be optionally provided to change the default (`left`) alignment of faces in the column.
@@ -135,11 +145,13 @@ Sets the layout direction to vertical, from top to bottom. An alignment modifier
 === return 
 
 *Syntax*
+
 ----
 return <alignment>
 
 <alignment> : (optional) possible values: left | center | right | top | middle | bottom.
 ---- 
+
 *Description*
 
 Moves the position to the next row or column of faces, depending on the current layout direction. An alignment modifier can be optionally provided to change the current alignment of faces in the row or column.
@@ -148,11 +160,13 @@ Moves the position to the next row or column of faces, depending on the current 
 === space 
 
 *Syntax*
+
 ----
 space <offset>
 
 <offset> : new spacing value (pair!).
 ----
+
 *Description*
 
 Sets the new spacing offset which will be used for placement of following faces.
@@ -161,11 +175,13 @@ Sets the new spacing offset which will be used for placement of following faces.
 === origin 
 
 *Syntax*
+
 ----
 origin <offset>
 
 <offset> : new origin value (pair!).
 ----
+
 *Description*
 
 Sets the new origin position, relative to container face.
@@ -174,11 +190,13 @@ Sets the new origin position, relative to container face.
 === at
 
 *Syntax*
+
 ----
 at <offset>
 
 <offset> : position of next face (pair!).
 ----
+
 *Description*
 
 Places the next face at an absolute position. This positioning mode only affects the next following face, and does not change the layout flow position. So, the following faces, after the next one, will be placed again in the continuity of the previous ones in the layout flow.
@@ -187,11 +205,13 @@ Places the next face at an absolute position. This positioning mode only affects
 === pad 
 
 *Syntax*
+
 ----
 pad <offset>
 
 <offset> : relative offset (pair!).
 ----
+
 *Description*
 
 Modifies the layout current position by a relative offset. All the following faces on the same row (or column) are affected.
@@ -200,11 +220,13 @@ Modifies the layout current position by a relative offset. All the following fac
 === do 
 
 *Syntax*
+
 ----
 do <body>
 
 <body> : code to evaluate (block!).
 ----
+
 *Description*
 
 Evaluates a block of regular Red code, for last-minute initialization needs. The body block is bound to the container face (window or panel), so direct access to container's facet is possible. The container itself can be referred to using the `self` keyword.
@@ -246,6 +268,7 @@ The `image` style is a `base` type of default size 100x100. It expects an `image
 A face can be inserted in the layout, at the current position, simply by using the name of an existing face type or one of the available styles.
 
 *Syntax*
+
 ----
 <name>: <type> <options>
 
@@ -253,6 +276,7 @@ A face can be inserted in the layout, at the current position, simply by using t
 <type>    : a valid face type or style name (word!).
 <options> : optional list of options.
 ----
+
 If a name is provided, the word will reference the `face!` object created by VID from the face description.
 
 Default values are provided for each face type or style, so a new face can be used without having to specify any option. When options are required, the following sections are describing the different types of accepted options:
@@ -270,9 +294,11 @@ NOTE: `window` cannot be used as a face type.
 ==== left
 
 *Syntax*
+
 ----
 left
 ---- 
+
 *Description*
 
 Aligns the face's text to left side.
@@ -281,9 +307,11 @@ Aligns the face's text to left side.
 ==== center
 
 *Syntax*
+
 ----
 center
 ----
+
 *Description*
 
 Centers the face's text.
@@ -292,9 +320,11 @@ Centers the face's text.
 ==== right
 
 *Syntax*
+
 ----
 right
 ----
+
 *Description*
 
 Aligns the face's text to right side.
@@ -303,9 +333,11 @@ Aligns the face's text to right side.
 ==== top
 
 *Syntax*
+
 ----
 top
 ----
+
 *Description*
 
 Vertically align the face's text to `top`.
@@ -314,9 +346,11 @@ Vertically align the face's text to `top`.
 ==== middle
 
 *Syntax*
+
 ----
 middle
 ----
+
 *Description*
 
 Vertically align the face's text to `middle`.
@@ -325,9 +359,11 @@ Vertically align the face's text to `middle`.
 ==== bottom
 
 *Syntax*
+
 ----
 bottom
 ----
+
 *Description*
 
 Vertically align the face's text to `bottom`.
@@ -336,9 +372,11 @@ Vertically align the face's text to `bottom`.
 ==== bold
 
 *Syntax*
+
 ----
 bold
 ----
+
 *Description*
 
 Sets the face's text style to `bold`.
@@ -347,9 +385,11 @@ Sets the face's text style to `bold`.
 ==== italic
 
 *Syntax*
+
 ----
 italic
 ----
+
 *Description*
 
 Sets the face's text style to `italic`.
@@ -358,9 +398,11 @@ Sets the face's text style to `italic`.
 ==== underline
 
 *Syntax*
+
 ----
 underline
 ----
+
 *Description*
 
 Sets the face's text style to `underline`.
@@ -382,11 +424,13 @@ Sets the face's `extra` facet to a value (can be the result of a Red expression)
 ==== data
 
 *Syntax*
+
 ----
 data <list>
 
 <list> : literal list of items or a Red expression (block!).
 ----
+
 *Description*
 
 Sets the face's `data` facet to a list of values. Format of the list depends on the face type requirements.
@@ -395,27 +439,31 @@ Sets the face's `data` facet to a list of values. Format of the list depends on 
 ==== draw
 
 *Syntax*
+
 ----
 draw <commands>
 
 <commands> : literal list commands or Red expression (block!).
 ---- 
+
 *Description*
 
-Sets the face's `draw` facet to a list of Draw dialect commands. See link:draw.html[Draw dialect documentation] for valid commands.
+Sets the face's `draw` facet to a list of Draw dialect commands. See link:draw.adoc[Draw dialect documentation] for valid commands.
 
 
 ==== font
 
 *Syntax*
+
 ----
 font <spec>
 
 <spec> : a valid font specification (block! object! word!).
 ----
+
 *Description*
 
-Sets the face's `font` facet to a new `font!` object. Font! object is described link:view.html#_font_object[here].
+Sets the face's `font` facet to a new `font!` object. Font! object is described link:view.adoc#_font_object[here].
 
 NOTE: It's possible to use `font` along with other font-related settings, VID will merge them together, giving priority to the last one specified.
 
@@ -423,14 +471,16 @@ NOTE: It's possible to use `font` along with other font-related settings, VID wi
 ==== para
 
 *Syntax*
+
 ----
 para <spec>
 
 <spec> : a valid para specification (block! object! word!).
 ----
+
 *Description*
 
-Sets the face's `para` facet to a new `para!` object. Para! object is described link:view.html#_para_object[here].
+Sets the face's `para` facet to a new `para!` object. Para! object is described link:view.adoc#_para_object[here].
 
 NOTE: It possible to use `para` along with other para-related settings, VID will merge them together, giving priority to the last one specified.
 
@@ -438,6 +488,7 @@ NOTE: It possible to use `para` along with other para-related settings, VID will
 ==== wrap
 
 *Syntax*
+
 ----
 wrap
 ----
@@ -450,9 +501,11 @@ Wrap the face's text when displaying.
 ==== no-wrap
 
 *Syntax*
+
 ----
 no-wrap
 ----
+
 *Description*
 
 Avoid wrapping the face's text when displaying.
@@ -461,11 +514,13 @@ Avoid wrapping the face's text when displaying.
 ==== font-size
 
 *Syntax*
+
 ----
 font-size <pt>
 
 <pt> : font size in points (integer! word!).
 ----
+
 *Description*
 
 Sets the current font size for the face's text.
@@ -474,11 +529,13 @@ Sets the current font size for the face's text.
 ==== font-color
 
 *Syntax*
+
 ----
 font-color <value>
 
 <value> : color of the font (tuple! word! issue!).
 ----
+
 *Description*
 
 Sets the current font color for the face's text.
@@ -487,11 +544,13 @@ Sets the current font color for the face's text.
 ==== font-name
 
 *Syntax*
+
 ----
 font-name <name>
 
 <name> : valid name of an available font (string! word!).
 ----
+
 *Description*
 
 Sets the current font name for the face's text.
@@ -502,27 +561,29 @@ Sets the current font name for the face's text.
 This keyword can be used both as a face option or as a global keyword. Arbitrary number of `react` instances can be used.
 
 *Syntax*
+
 ----
 react [<body>]
 react later [<body>]
 
 <body> : regular Red code (block!).
 ----
+
 *Description*
 
 Creates a new reactor from the body block. When `react` is used as a face option, the body can refer to the current face using `face` word. When `react` is used globally, target faces need to be accessed using a name. The optional `later` keyword skips the first reaction happening immediately after the `body` block is processed.
 
-NOTE:
-
-Reactors are part of the reactive programming support in View, which documentation is pending. In a nutshell, the body block can describe one or more relations between faces properties using paths. Set-path setting a face property are processed as *target* of the reactor (the face to update), while path accessing a face property are processed as *source* of the reactor (a change on a source triggers a refresh of the reactor's code).
+NOTE: Reactors are part of the reactive programming support in View, which documentation is pending. In a nutshell, the body block can describe one or more relations between faces properties using paths. Set-path setting a face property are processed as *target* of the reactor (the face to update), while path accessing a face property are processed as *source* of the reactor (a change on a source triggers a refresh of the reactor's code).
 
 
 ==== loose
 
 *Syntax*
+
 ----
 loose
 ----
+
 *Description*
 
 Enables dragging of the face using the left mouse button.
@@ -531,9 +592,11 @@ Enables dragging of the face using the left mouse button.
 ==== all-over
 
 *Syntax*
+
 ----
 all-over
 ----
+
 *Description*
 
 Sets the face `all-over` flag, allowing all mouse `over` events to be received.
@@ -542,9 +605,11 @@ Sets the face `all-over` flag, allowing all mouse `over` events to be received.
 ==== hidden
 
 *Syntax*
+
 ----
 hidden
 ----
+
 *Description*
 
 Makes the face invisible by default.
@@ -553,9 +618,11 @@ Makes the face invisible by default.
 ==== disabled
 
 *Syntax*
+
 ----
 disabled
 ----
+
 *Description*
 
 Disables the face by default (the face will not process any event until it is enabled).
@@ -564,11 +631,13 @@ Disables the face by default (the face will not process any event until it is en
 ==== select
 
 *Syntax*
+
 ----
 select <index>
 
 <index> : index of selected item (integer!).
 ----
+
 *Description*
 
 Sets the `selected` facet of the current face. Used mostly for lists to indicate which item is pre-selected.
@@ -577,9 +646,11 @@ Sets the `selected` facet of the current face. Used mostly for lists to indicate
 ==== focus
 
 *Syntax*
+
 ----
 focus
 ---- 
+
 *Description*
 
 Gives the focus to the current face when the window is displayed for the first time. Only one face can have the focus. If several `focus` options are used on different faces, only the last one will get the focus.
@@ -587,11 +658,13 @@ Gives the focus to the current face when the window is displayed for the first t
 ==== hint
 
 *Syntax*
+
 ----
 hint <message>
 
 <message> : hint text (string!).
 ---- 
+
 *Description*
 
 Provides a hint message inside `field` faces, when the field's content is empty. That text disappears when any new content is provided (user action or setting the `face/text` facet).
@@ -600,12 +673,14 @@ Provides a hint message inside `field` faces, when the field's content is empty.
 ==== rate
 
 *Syntax*
+
 ----
 rate <value>
 rate <value> now
 
 <value>: duration or frequency (integer! time!).
 ----
+
 *Description*
 
 Sets a timer for the face from a duration (time!) or a frequency (integer!). At each timer's tick, a `time` event will be generated for that face. If `now` option is used, a first time event is generated immediately.
@@ -614,11 +689,13 @@ Sets a timer for the face from a duration (time!) or a frequency (integer!). At 
 ==== default
 
 *Syntax*
+
 ----
 default <value>
 
 <value>: a default value for `data` facet (any-type!).
 ----
+
 *Description*
 
 Defines a default value for `data` facet when the conversion of `text` facet returns `none`. That default value is stored in `options` facet, as a key/value pair.
@@ -628,11 +705,13 @@ NOTE: currently used only by `text` and `field` face types.
 ==== with
 
 *Syntax*
+
 ----
 with <body>
 
-<body>: a Red block of code bound to the current face (block!).
+<body>: a block of Red code bound to the current face (block!).
 ----
+
 *Description*
 
 Evaluates a block of Red code bound to the currently defined face. Allows directly setting the face fields, overriding other VID options.
@@ -663,6 +742,7 @@ In addition to keywords, it is allowed to pass settings to faces using literal v
 An actor can be hooked to a face by specifying a literal block value or an actor name followed by a block value.
 
 *Syntax*
+
 ----
 <actor>
 on-<event> <actor>
@@ -670,15 +750,18 @@ on-<event> <actor>
 <actor> : actor's body block or actor reference (block! get-word!).
 <event> : valid event name (word!). 
 ----
+
 *Description*
 
 It is possible to specify actors in a simplified way by providing just the body block of the actor, the spec block being implicit. The actor function gets constructed then and added to the face's `actor` facet. Several actors can be specified that way.
 
 The created actor function full specification is:
+
 ----
 func [face [object!] event [event! none!]][...body...]
 ----
-The valid list of event names can be found link:view.html#_actors[here].
+
+The valid list of event names can be found link:view.adoc#_actors[here].
 
 When a block or a get-word is passed without any actor name prefix, the default actor for the face type is created according to the definitions https://github.com/red/red/blob/master/modules/view/styles.red[here].
 
@@ -692,12 +775,14 @@ The panel-class face types from View are supported in VID with a specific syntax
 === panel 
 
 *Syntax*
+
 ----
 panel <options> [<content>]
 
 <options> : optional list of settings for the panel.
 <content> : panel's VID content description (block!).
 ----
+
 *Description*
 
 Constructs a child panel inside the current container, where the content is another VID block. In addition to other face options, an integer divider option can be provided, setting a grid-mode layout:
@@ -710,6 +795,7 @@ Constructs a child panel inside the current container, where the content is anot
 === group-box 
 
 *Syntax*
+
 ----
 group-box <divider> <options> [<body>]
 
@@ -717,6 +803,7 @@ group-box <divider> <options> [<body>]
 <options> : optional list of settings for the panel.
 <body>    : panel's VID content description (block!).
 ----
+
 *Description*
 
 Constructs a child group-box panel inside the current container, where the content is another VID block. A divider argument can be provided, setting a grid-mode layout:
@@ -730,6 +817,7 @@ NOTE: Providing a `string!` value as option will set the group-box title text.
 === tab-panel 
 
 *Syntax*
+
 ----
 tab-panel <options> [<name> <body>...]
 
@@ -737,6 +825,7 @@ tab-panel <options> [<name> <body>...]
 <name>    : a tab's title (string!).
 <body>    : a tab's content as VID description (block!).
 ----
+
 *Description*
 
 Constructs a tab-panel inside the current container. The spec block must contain a pair of name and content description for each tab. Each tab's content body is a new child panel face, acting as any other panels.
@@ -747,6 +836,7 @@ Constructs a tab-panel inside the current container. The spec block must contain
 === style 
 
 *Syntax*
+
 ----
 style <new> <old> <options>
 
@@ -754,6 +844,7 @@ style <new> <old> <options>
 <old>     : name of old style (word!).
 <options> : optional list of settings for the new style.
 ----
+
 *Description*
 
 Sets a new style in the current panel. The new style can be created from existing face types or from other styles. The new style is valid only in the current panel and child panels.

--- a/en/view.adoc
+++ b/en/view.adoc
@@ -64,12 +64,13 @@ List of globally-usable flags for `flags` facet:
 
 Other face types specific flags are documented in their respective sections.
 
-Notes:
-
+[NOTE]
+====
 * Non-mandatory facets can be set to `none`.
 * `offset` and `size` are specified in screen pixels.
 * `offset` and `size` can sometime be set to `none` before displaying them. The View engine will take care of setting the values (like for panels in tab-panel type).
 * Display order (from back to front): color, image, text, draw.
+====
 
 Creating a new face is achieved by cloning the `face!` object and providing *at least* a valid `type` name.
 
@@ -106,11 +107,12 @@ Font objects are clones of `font!` template object. One font object can be refer
 |parent| block!| no| Internal back reference to parent face(s) _(used by View engine only)_.
 |===
 
-Notes:
-
+[NOTE]
+====
 * Non-mandatory facets can be set to `none`.
 * `angle` field is not yet working properly.
 * All fields values should become optional in the future.
+====
 
 Available font styles:
 
@@ -142,9 +144,10 @@ Para objects are clones of `para!` template object. One para object can be refer
 |parent| block!| Internal back reference to parent face(s) _(used by View engine only)_.
 |===
 
-Notes:
-
+[NOTE]
+====
 * Any para fields can be set to `none`.
+====
 
 == The Face tree 
 
@@ -178,10 +181,11 @@ The `base` type is the most basic face type, but also the most versatile one. By
 |`draw`| Transparency is fully supported for Draw primitives.
 |===
 
-Notes:
-
+[NOTE]
+====
 * Full composition of following facets is supported and rendered in following order: `color`, `image`, `text`, `draw`.
 * Transparency can be achieved in `color`, `image`, `text` and `draw` by specifying an alpha channel component in color tuple values: `R.G.B.A` where `A = 0` indicates full opacity and `A = 255` full transparency.
+====
 
 _This face type should be used for any custom graphic component implementation._
 
@@ -302,9 +306,10 @@ This type represents a single-line input field.
 
 * `default`: can be set to any value, it will be used by the `data` facet if converting `text` returns `none`, like for non-loadable strings.
 
-NOTE:
-
+[NOTE]
+====
 * `selected` will be used in future to control highlighted part of the input text.
+====
 
 [cols="1, 1, 3", options="header"]
 |===
@@ -333,16 +338,17 @@ This type represents a multi-line input field.
 
 * `no-border`: removes edge decoration made by the underlying GUI framework.
 
-Notes:
-
+[NOTE]
+====
 * `selected` will be used in future to control highlighted part of the input text.
 * A vertical scroll-bar can appear if all lines of text cannot be visible in the area (might be controlled by a `flags` option in the future).
+====
 
 [cols="1, 1, 2", options="header"]
 |===
 |Event type| Handler| Description
 |`change`| `on-change`| Occurs each time an input is made in the area.
-|`key`| `on-key`\ Occurs each time a key is pressed down in the field.
+|`key`| `on-key`| Occurs each time a key is pressed down in the area.
 |===
 
 '''
@@ -367,9 +373,10 @@ This type represents a vertical list of text strings, displayed in a fixed frame
 |`change`| `on-change`| Occurs after a `select` event. `selected` facet refers to the *new* selected entry index.
 |===
 
-Notes:
-
+[NOTE]
+====
 * number of visible items cannot yet be defined by user.
+====
 
 
 === Drop-list 
@@ -396,9 +403,10 @@ The `data` facet accepts arbitrary values, but only string values will be added 
 |`change`| `on-change`| Occurs after a `select` event. `selected` facet refers to the *new* selected entry index.
 |===
 
-Notes:
-
+[NOTE]
+====
 * number of visible items cannot yet be defined by user.
+====
 
 
 === Drop-down 
@@ -423,9 +431,10 @@ The `data` facet accepts arbitrary values, but only string values will be added 
 |`change`| `on-change`| Occurs after a `select` event. `selected` facet refers to the *new* selected entry index.
 |===
 
-Notes:
-
+[NOTE]
+====
 * number of visible items cannot yet be defined by user.
+====
 
 
 === Progress 
@@ -440,9 +449,10 @@ This type represents a horizontal or vertical progress bar.
 |`data`| Value representing the progression (`percent!` or `float!` value).
 |===
 
-Notes:
-
+[NOTE]
+====
 * if a float value is used for `data`, it needs to be between 0.0 and 1.0.
+====
 
 
 === Slider 
@@ -456,9 +466,10 @@ This type represents a cursor which can be moved along a horizontal or vertical 
 |`data`| Value representing the cursor position (`percent!` or `float!` value).
 |===
 
-Notes:
-
+[NOTE]
+====
 * if a float value is used for `data`, it needs to be between 0.0 and 1.0.
+====
 
 
 === Camera 
@@ -473,10 +484,11 @@ This type is used to display a video camera feed.
 |`selected`| Select the camera to display from `data` list, using an integer index. If set to `none`, the camera feed is disabled.
 |===
 
-Notes:
-
+[NOTE]
+====
 * The `data` facet is initially set to `none`. The list of cameras is fetched during the first call to `show` on the camera face.
 * It is possible to capture the content of a camera face using `to-image` on the face.
+====
 
 
 
@@ -492,10 +504,11 @@ A panel is a container for other faces.
 |`pane`| Block of children faces. Order in block defines z-order on display.
 |===
 
-Notes:
-
+[NOTE]
+====
 * Children `offset` coordinates are relative to parent's panel top-left corner.
 * Children faces are clipped into the panel frame.
+====
 
 '''
 
@@ -518,11 +531,12 @@ A tab-panel is a list of panels where only one can be visible at a given time. A
 |`change`| on-change| Occurs when user selects a new tab. `event/picked` holds the index of the newly selected tab. `selected` property is updated just after this event.
 |===
 
-Notes:
-
+[NOTE]
+====
 * Both `data` and `pane` facets need to be filled in order for the tab-panel to be displayed properly.
 * If `pane` contains more panels than specified tabs, they will be ignored.
 * When adding/removing a tab, the corresponding panel needs to be added/removed too to/from `pane` list.
+====
 
 
 
@@ -555,9 +569,10 @@ Represents a window displayed on the OS desktop.
 * `no-buttons`: remove all buttons from window's drag bar.
 * `popup`: alternative smaller frame decoration (Windows only).
 
-Notes:
-
+[NOTE]
+====
 * Using the `popup` keyword at the beginning of the menu specification block will force a contextual menu in the window, instead of a menu bar by default.
+====
 
 
 === Screen 
@@ -586,10 +601,11 @@ A group-box is a container for other faces, with a visible frame around it. _Thi
 |`pane`| Block of children faces. Order in block defines z-order on display.
 |===
 
-Notes:
-
+[NOTE]
+====
 * Children `offset` coordinates are relative to group-box's top-left corner.
 * Children faces are clipped into the group-box frame.
+====
 
 
 == Face life cycle 
@@ -602,9 +618,10 @@ Notes:
 . Remove the face from the pane to remove it from the display.
 . The garbage collector will take care of releasing the system resources associated when the face is not referenced anymore.
 
-Notes:
-
+[NOTE]
+====
 * A `free` function might be provided for manual control of system resources freeing for resources hungry applications.
+====
 
 == SHOW function 
 
@@ -633,10 +650,11 @@ _The following information is provided only for reference, in normal operation, 
 |4 (drag-offset)| Stores the starting mouse cursor offset position when entering face dragging mode (`pair!` `none!`).
 |===
 
-Notes:
-
+[NOTE]
+====
 * After a call to `show`, `changes` field is reset to 0 and `deferred` field block is cleared.
 * A `handle!` datatype will be used in the future for opaque OS handles.
+====
 
 == Realtime vs deferred updating anchor:realtime-vs-deferred-updating[]
 
@@ -657,9 +675,10 @@ The motivations for realtime updating by default are:
 
 Deferred mode updates many changes at the same time on screen in order to avoid glitches or when best performance is the goal.
 
-Notes:
-
+[NOTE]
+====
 * This is a big difference with the Rebol/View engine which only has deferred mode support.
+====
 
 == Two-way binding 
 
@@ -670,6 +689,7 @@ On the other side, changes made to the rendered graphic objects are reflected in
 This two-way binding simplifies the interaction with the graphic objects for the programmer, without the need of any specific API. Modifying the facets using the series actions is enough.
 
 Example:
+
 ----
 view [
     list: text-list data ["John" "Bob" "Alice"]
@@ -677,6 +697,7 @@ view [
     button "Change" [lowercase pick list/data list/selected]
 ]
 ----
+
 == Events 
 
 === Event names 
@@ -722,11 +743,12 @@ view [
 |*time*| timer| The delay set by face's `rate` facet expired.
 |===
 
-Notes:
-
+[NOTE]
+====
 * touch events are not available for Windows XP.
 * One or more `moving` events always precedes a `move` one.
 * One or more `resizing` events always precedes a `resize` one.
+====
 
 === Event! datatype 
 
@@ -760,9 +782,10 @@ List of possible flags from `event/flags`:
 * `control`
 * `shift`
 
-Notes:
-
+[NOTE]
+====
 * All fields (except `type`) are read-only. Setting `type` is only used internally by the View engine.
+====
 
 Here is the list of special keys returned as words by `event/key`:
 
@@ -804,6 +827,7 @@ The following extra key names can be returned by `event/key` only for `key-down`
 Actors are handler functions for View events. They are defined in an free-form object (no prototype provided) referred by `actors` facet. All actors have the same specification block.
 
 *Syntax*
+
 ----
 on-<event>: func [face [object!] event [event!]]
 
@@ -811,13 +835,16 @@ on-<event>: func [face [object!] event [event!]]
 face    : face object which receives the event
 event   : event value.
 ----
+
 In addition to the GUI events, it is possible to define an `on-create` actor which will be called when the face is shown for the first time, just before system resources are allocated for it. Unlike other actors, `on-create` has only one argument, `face`.
 
 *Return value*
+
 ----
 'stop : exits the event loop.
 'done : stops the event from flowing to the next face.
 ----
+
 Other returned values have no effect.
 
 === Event flow 
@@ -842,10 +869,11 @@ Typical event flow path:
 .. The panel gets the event next. Panel's `on-click` handler gets called.
 .. The window gets the event last, its `on-click` handler gets called.
 
-Notes:
-
+[NOTE]
+====
 * Event cancellation is achieved by returning `'done` word from any event handler.
 * Event capturing is not enabled by default for performance reasons. Set `system/view/capturing?: yes` to enable it.
+====
 
 === Global event handlers 
 
@@ -854,6 +882,7 @@ Before entering the event flow path, specific pre-processing can be achieved usi
 ==== insert-event-func
 
 *Syntax*
+
 ----
 insert-event-func <handler>
 
@@ -861,10 +890,13 @@ insert-event-func <handler>
 
 Handler's function specification: func [face [object!] event [event!]]
 ----    
+
 *Return value*
+
 ----
-The newly added handler function (function!).
+The newly added handler function (`function!`).
 ----    
+
 *Description*
 
 Installs a global handler function, which can pre-process events before they reach the face handlers. All global handlers are called on each event, so the handler's body code needs to be optimized for speed and memory usage. If a block is provided as argument, it will be converted to a function using the `function` constructor.
@@ -880,11 +912,13 @@ A reference to the handler function is returned and should be saved if it needs 
 ==== remove-event-func
 
 *Syntax*
+
 ----
 remove-event-func <handler>
 
 <handler> : a previously installed event handler function.
 ----
+
 *Description*
 
 Disables a previously installed global event handler by removing it from the internal list.
@@ -914,13 +948,14 @@ Disables a previously installed global event handler by removing it from the int
 == Including View component 
 
 View component is not included by default on *compiling*. To include it, the main Red script have to declare the dependency in the header using the `Needs` field:
+
 ----
 Red [
     Needs: 'View
 ]
 ----
-NOTE:
-Using consoles auto-generated by `red` binary will include the View component on platforms where it is available, `Needs` header field is therefore not required in user scripts run from those consoles.
+
+NOTE: Using consoles auto-generated by `red` binary will include the View component on platforms where it is available, `Needs` header field is therefore not required in user scripts run from those consoles.
 
 == Extra functions 
 

--- a/ja/libred.adoc
+++ b/ja/libred.adoc
@@ -345,7 +345,7 @@ Redのstring!の値からUTF-8の文字列バッファポインタを返しま�
 long redTypeOf(red_value value)
 ----
 
-Redの値の型IDを返します。型IDは `RedType` 列挙体で定義されています。link:libred.adoc#_datatypes_definition[データ型] セクションを参照してください。
+Redの値の型IDを返します。型IDは `RedType` 列挙体で定義されています。link:libred.adoc#datatypes-definition[データ型] セクションを参照してください。
 
 === Redのactionの呼び出し
 
@@ -585,6 +585,7 @@ void redCloseLogFile(void)
 
 NOTE: 現在のところ、ログファイルは終了時には必ず閉じておく必要があります。ログファイルを閉じずに終了した場合、ロックが残ってしまい、MS Officeアプリケーションなどの一部のホストではフリーズやクラッシュが起きる可能性があります。
 
+[#datatypes-definition]
 === データ型の定義
 
 libRed APIのいくつかの関数はRedのデータ型を参照します。具体的には `redTypeOf`、`redMakeSeries()`、`redDataType()`です。Redのデータ型はホストの側で`RedType`列挙体として表現され、次の命名規則で型を示します。


### PR DESCRIPTION
In `draw.adoc` fill pen section, there are possible typos. The "circle" is probably copy-pasted and forgot to change. And an possible error is in parameter description of `arc`. Also there is a repetition "See See".

In `libred.doc`, the "note" words in some note sections are not all uppercase. The format is not correct.

In `libred.doc` of Česky and Japanese verson, the link under `redTypeOf()` is broken. I fixed it by adding explicit ID for header.