### PR TITLE
FIX: Update syntax of date! refinement /timezone

### DIFF
--- a/en/date.adoc
+++ b/en/date.adoc
@@ -462,10 +462,10 @@ d/zone: -4:00
 *Syntax*
 ----
 <date>/timezone
-<date>/timezone: <zone>
+<date>/timezone: <timezone>
 
 <date>     : a word or path expression referring to a date! value
-<timezone> : an integer!, time! or pair! value
+<timezone> : an integer! or time! value
 ----
 *Description*
 


### PR DESCRIPTION
It might be forgotten to replace "zone" by "timezone" after copy.
And according to former zone description and set-timezone source code in %runtime/datatypes/date.reds ( https://github.com/red/red/blob/master/runtime/datatypes/date.reds#L453 )
Set-timezone does not accept a pair! value.