### PR TITLE
FIX: rephrase section 4

### DIFF
--- a/en/datatypes/block.adoc
+++ b/en/datatypes/block.adoc
@@ -102,7 +102,7 @@ Not ok: `[42 pr   int "foo"]`
 
 == Accessing block elements
 
-A block can be indexed with so-called _path notation_, using integer value for 1-based indexing:
+A block can be indexed with _path notation_, using integer values for 1-based indexing:
 
 ----
 >> b: [12 [34 56]]
@@ -115,7 +115,7 @@ A block can be indexed with so-called _path notation_, using integer value for 1
 == 56
 ----
 
-A block (and any `any-list!` value for that matter) can also be treated as key/value store;
+A block (and any `any-list!` value for that matter) can also be treated as a key/value store;
 in such case the first occurence of value, supplied to path, will be searched, and the value
 that follows it will be returned.
 
@@ -132,7 +132,6 @@ that follows it will be returned.
 >> b/y/z
 == 34
 ----
-
 
 == Comparisons
 

--- a/en/datatypes/block.adoc
+++ b/en/datatypes/block.adoc
@@ -102,26 +102,34 @@ Not ok: `[42 pr   int "foo"]`
 
 == Accessing block elements
 
-Elements of block variables can be accessed using slash and index of an element:
+A block can be indexed with so-called _path notation_, using integer value for 1-based indexing:
 
 ----
->> b: [12 34 56]
-== [12 34 56]
+>> b: [12 [34 56]]
+== [12 [34 56]]
 
 >> b/1
 == 12
+
+>> b/2/2
+== 56
 ----
 
-A block can also be treated as key/value store:
+A block (and any `any-list!` value for that matter) can also be treated as key/value store;
+in such case the first occurence of value, supplied to path, will be searched, and the value
+that follows it will be returned.
 
 ----
->> b: [x 12 y 34]
-== [x 12 y 34]
+>> b: [x 12 y [z 34]]
+== [x 12 y [z 34]]
 
 >> b/x
 == 12
 
 >> b/y
+== [z 34]
+
+>> b/y/z
 == 34
 ----
 


### PR DESCRIPTION
I believe topic can be extended further, to explain what happens with out-of-boundary indexes and non-existent keys, relation to `pick` with `select`, using path indexing with `any-list!` and values other than `word!` and `integer!` &c.