### PR TITLE
FEAT: describe missing keywords and document 3-state check box mode

### DIFF
--- a/en/vid.adoc
+++ b/en/vid.adoc
@@ -633,6 +633,19 @@ disabled
 
 Disables the face by default (the face will not process any event until it is enabled).
 
+==== password
+
+*Syntax*
+
+----
+password
+----
+
+*Description*
+
+Hides user's input in a text field.
+
+
 ==== tri-state
 
 *Syntax*

--- a/en/vid.adoc
+++ b/en/vid.adoc
@@ -758,6 +758,7 @@ In addition to keywords, it is allowed to pass settings to faces using literal v
 |tuple!|	Specifies the color of the face's background (where applicable).
 |issue!|	Specifies the color of the face's background using hex notation (#rgb, #rrggbb, #rrggbbaa).
 |string!|	Specifies the text to be displayed by the face.
+|date!|		Sets the `data` facet (useful for `calendar` type).
 |percent!|	Sets the `data` facet (useful for `progress` and `slider` types).
 |logic!|	Sets the `data` facet (useful for `check` and `radio` types).
 |image!| 	Sets the image to be displayed as face's background (where applicable).

--- a/en/vid.adoc
+++ b/en/vid.adoc
@@ -633,6 +633,17 @@ disabled
 
 Disables the face by default (the face will not process any event until it is enabled).
 
+==== tri-state
+
+*Syntax*
+
+----
+tri-state
+----
+
+*Description*
+
+Enables 3-state mode of a check box.
 
 ==== select
 

--- a/en/view.adoc
+++ b/en/view.adoc
@@ -245,8 +245,13 @@ This type represents a check box, with an optional label text, displayed on left
 |`type`| `'check`
 |`text`| Label text.
 |`para`| The `align` field controls if the text is displayed on the `left` or on the `right` side.
-|`data`| `true`: checked; `false`: unchecked (default).
+|`data`| `true`: checked; `false`: unchecked; `none`: unchecked for 2-state check box, indeterminate for 3-state check box.
+|`flags`| Turn on tri-state check box feature (word!).
 |===
+
+*Supported flags:*
+
+* `tri-state`: enables third, indeterminate state that is represented as `none` value in `data` facet.
 
 [cols="1, 1, 3", options="header"]
 |===


### PR DESCRIPTION
Adds mention of `password` flag, describes usage of `date!` datatype for `calendar` widget and documents newly added `tri-state` flag with 3-state check box mode.