### PR TITLE
FIX: malformed REF! literal introduced by 31aa77f.

### DIFF
--- a/en/datatypes/ref.adoc
+++ b/en/datatypes/ref.adoc
@@ -33,7 +33,7 @@
 @
 @red_lang
 @dockimbel
-@$2.1
+@§2.1
 ----
 
 === Runtime construction


### PR DESCRIPTION
@Tovim can you elaborate on why this change was made? It goes against the syntactic rules described in section 2.1.
```red
>> @$2.1
*** Syntax Error: (line 1) invalid ref at @$2.1
*** Where: transcode
*** Stack: load 
```