### PR TITLE
FEAT: Redbin documentation.

### DIFF
--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -232,7 +232,9 @@ Compact: TBD
 header/type=1
 ----
 
-=== Unset! anchor:unset[] 
+`value` field contains datatype ID represented as a 32-bit integer.
+
+==== `unset!` anchor:unset[] 
 
 ----
 Default: header (4)
@@ -241,7 +243,9 @@ Compact: TBD
 header/type=2
 ----
 
-=== None! anchor:none[] 
+`unset!` is a singleton value and can be encoded as a `header` field with datatype ID.
+
+==== `none!` anchor:none[] 
 
 ----
 Default: header (4)
@@ -250,7 +254,9 @@ Compact: TBD
 header/type=3
 ----
 
-=== Logic! anchor:logic[] 
+`none!` is a singleton value and can be encoded as a `header` field with datatype ID.
+
+==== `logic!` anchor:logic[] 
 
 ----
 Default: header (4), value=0|1 (4)
@@ -259,64 +265,77 @@ Compact: TBD
 header/type=4
 ----
 
-=== Block! anchor:block[] 
+`value` content of `0` encodes a `false` value. Non-zero `value` content encodes a `true` value.
+
+==== `block!` anchor:block[] 
 
 ----
-Default: header (4), head (4), length (4), ...
-Compact: TBD
+Default:  header (4), head (4), length (4), ... * length
+Referral: header (4), head (4), [reference]
+Compact:  TBD
 
 header/type=5
+header/reference?=0|1
 ----
 
-The `head` field indicates the offset of the block reference, using a zero-based integer. The `length` field contains the number of values to be stored in the block. The block values simply follow the block definition, no separator or end delimiter is required.
+The `head` field indicates a zero-based offset of the index position from block's head. The `length` field contains the number of values to be stored in the block. The block values' records then follow the `length` field.
 
-=== Paren! anchor:paren[] 
+==== `paren!` anchor:paren[] 
 
 ----
-Default: header (4), head (4), length (4), ...
-Compact: TBD
+Default:  header (4), head (4), length (4), ... * length
+Referral: header (4), head (4), [reference]
+Compact:  TBD
 
 header/type=6
+header/reference?=0|1
 ----
 
-Same encoding rules as `block!`.
+Same encoding rules as <<block, `block!`>>.
 
-=== String! anchor:string[] 
+==== `string!` anchor:string[] 
 
 ----
-Default: header (4), head (4), length (4), data (unit*length) [, padding (1-3)]
-Compact: TBD
+Default:  header (4), head (4), length (4), data (header/unit * length), [padding] (1-3)
+Referral: header (4), head (4), [reference]
+Compact:  TBD
 
 header/type=7
 header/unit=1|2|4
+header/reference?=0|1
 ----
 
-`head` field has same meaning as for blocks. The `unit` sub-field indicates the encoding format of the string, only values of 1, 2 and 4 are valid. The `length` field contains the number of codepoints to be stored in the string, up to 16777215 codepoints (2^24 - 1) are supported. The string is encoded in UCS-1, UCS-2 or UCS-4 format. No NUL character is present, nor accounted for in the `length` field. An optional tail padding of 1 to 3 NUL bytes can be present to align the end of the `string!` record with a 32-bit boundary.
+The `head` field has same meaning as for other series values. The `unit` field indicates the encoding format of the string, only values of 1, 2 and 4 are valid. The `length` field contains the number of codepoints to be stored in the string, up to 16777215 codepoints (2^24^ - 1) are supported. The string is encoded in either UCS-1, UCS-2 or UCS-4 format, depending on the maximum width of contained codepoints. No NUL-terminating character is present in `data`, nor accounted for in the `length` field. An optional tail padding of 1 to 3 NUL bytes can be present to align the end of the `string!` record with the 32-bit boundary.
 
-=== File! anchor:file[] 
+==== `file!` anchor:file[] 
 
 ----
-Default: header (4), head (4), length (4), data (unit*length)
-Compact: TBD
+Default:  header (4), head (4), length (4), data (header/unit * length), [padding] (1-3)
+Referral: header (4), head (4), [reference]
+Compact:  TBD
 
 header/type=8
 header/unit=1|2|4
+header/reference?=0|1
 ----
 
-Same encoding rules as `string!`.
+Same encoding rules as <<string, `string!`>>.
 
-=== Url! anchor:url[] 
+==== `url!` anchor:url[] 
 
 ----
-Default: header (4), head (4), length (4), data (unit*length)
-Compact: TBD
+Default:  header (4), head (4), length (4), data (header/unit * length), [padding] (1-3)
+Referral: header (4), head (4), [reference]
+Compact:  TBD
 
 header/type=9
+header/unit=1|2|4
+header/reference?=0|1
 ----
 
-Same encoding rules as `string!`.
+Same encoding rules as <<string, `string!`>>.
 
-=== Char! anchor:char[] 
+==== `char!` anchor:char[] 
 
 ----
 Default: header (4), value (4)
@@ -325,7 +344,9 @@ Compact: TBD
 header/type=10
 ----
 
-=== Integer! anchor:integer[] 
+`value` field contains a UCS-4 codepoint stored as a 32-bit integer.
+
+==== `integer!` anchor:integer[] 
 
 ----
 Default: header (4), value (4)
@@ -333,6 +354,10 @@ Compact: TBD
 
 header/type=11
 ----
+
+`value` field contains a signed 32-bit integer that encoded Red value represents.
+
+= TBD
 
 === Float! anchor:float[] 
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -95,7 +95,7 @@ During the runtime booting process, these symbols are merged within Red's own sy
 
 After the symbol table, Red values are stored as a sequence of records, with no special delimiters or end markers. The loaded values from the root level are stored in a `block!` series.
 
-== Records definitions
+== Record definitions
 
 Each record in Redbin payload starts with a 32-bit `header` field defined as:
 
@@ -113,7 +113,7 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 | `context!`
 
 | 29
-| `stack?` flag; if set, indicates that values of a decoded `context!` are allocated on data stack.
+| `stack?` flag; if set, indicates that values of decoded `context!` are allocated on the data stack rather than on the heap memory.
 | `context!`
 
 | 28
@@ -196,16 +196,16 @@ Reference records are used to encode various relations between Red values, such 
 
 `length` field specifies the number of `offset` fields contained inside a reference record; each `offset` field specifies a zero-based offset to an already loaded Red value thru its parent, starting from the root block. A list of such offsets effectively forms a path to a referenced value.
 
-Red value that is used as a parent to calculate offset into is called a _waypoint_; Red value to which the path is formed by a reference is called an _apex_. Reference records are usually used by other value records in order to obtain datatype-specific parts that they share with the apex. Red value record that contains a reference is called a _referral_. In all record definitions that follow, referral format is used to describe such form of encoding, which is used only when `reference?` header flag of a respective value record is set.
+Red value that is used as a parent to calculate offset into is called a _waypoint_; Red value to which the path is formed by a reference is called an _target_. Reference records are usually used by other value records in order to obtain datatype-specific parts that they share with the target. Red value record that contains a reference is called a _referral_. In all record definitions that follow, referral format is used to describe such form of encoding, which is used only when `reference?` header flag of a respective value record is set.
 
 Redbin records that can act as referrals are: `series!`, `map!`, `bitset!`, `any-word!`, `refinement!`, `object!`, `native!`, `action!`, `function!`.
 
-Only a selected number of datatypes can be a waypoint or an apex, and rules of offset calculation and referencing for each of them are described in the table below.
+Only a selected number of datatypes can be a waypoint or a target, and rules of offset calculation and referencing for each of them are described in the table below.
 
 .Datatypes thru which reference paths can be formed.
 [options="header" cols="1,2,2"]
 |===
-| Datatypes | Waypoint | Apex
+| Datatypes | Waypoint | Target
 
 | `any-block!`, `map!`
 | An offset from the series' head. `map!` is treated as a linear block.
@@ -287,7 +287,7 @@ header/type=4
 
 ----
 Default:  header (4), head (4), length (4), ... * length
-Referral: header (4), head (4), [reference]
+Referral: header (4), head (4), buffer [reference]
 Compact:  TBD
 
 header/type=5
@@ -300,7 +300,7 @@ The `head` field indicates a zero-based offset of the index position from block'
 
 ----
 Default:  header (4), head (4), length (4), ... * length
-Referral: header (4), head (4), [reference]
+Referral: header (4), head (4), buffer [reference]
 Compact:  TBD
 
 header/type=6
@@ -312,8 +312,8 @@ Same encoding rules as <<block, `block!`>>.
 ==== `string!` anchor:string[] 
 
 ----
-Default:  header (4), head (4), length (4), data (header/unit * length), [padding] (1-3)
-Referral: header (4), head (4), [reference]
+Default:  header (4), head (4), length (4), data (unit * length), padding (1-3)
+Referral: header (4), head (4), buffer [reference]
 Compact:  TBD
 
 header/type=7
@@ -326,8 +326,8 @@ The `head` field has same meaning as for other series values. The `unit` field i
 ==== `file!` anchor:file[] 
 
 ----
-Default:  header (4), head (4), length (4), data (header/unit * length), [padding] (1-3)
-Referral: header (4), head (4), [reference]
+Default:  header (4), head (4), length (4), data (unit * length), padding (1-3)
+Referral: header (4), head (4), buffer [reference]
 Compact:  TBD
 
 header/type=8
@@ -340,8 +340,8 @@ Same encoding rules as <<string, `string!`>>.
 ==== `url!` anchor:url[] 
 
 ----
-Default:  header (4), head (4), length (4), data (header/unit * length), [padding] (1-3)
-Referral: header (4), head (4), [reference]
+Default:  header (4), head (4), length (4), data (unit * length), padding (1-3)
+Referral: header (4), head (4), buffer [reference]
 Compact:  TBD
 
 header/type=9
@@ -373,90 +373,109 @@ header/type=11
 
 `value` field contains a signed 32-bit integer that encoded Red value represents.
 
-= TBD
-
-=== Float! anchor:float[] 
+==== `float!` anchor:float[] 
 
 ----
-Default: [padding=0 (4),] header (4), value (8)
+Default: padding [padding], header (4), value (8)
 Compact: TBD
 
 header/type=12
+----
+
+An optional `padding` field is added to properly align the `value` field at 64-bit boundary. `value` field itself contains a 64-bit https://en.wikipedia.org/wiki/IEEE_754[IEEE 754] floating-point numeral.
+
+==== `context!` anchor:context[] 
 
 ----
-The optional padding field is added to properly align the `value` field offset to a 64-bit boundary.
-
-=== Context! anchor:context[] 
-
-----
-Default: header (4), length (4), symbol1 (4), symbol2 (4),..., value1 [any-type!], value2 [any-type!], ...
+Default: header (4), length (4), symbol (4) * length, ... * length
 Compact: TBD
 
 header/type=14
+header/kind=0|1|2
 header/no-values=0|1
 header/stack?=0|1
 header/self?=0|1
 ----
 
-Contexts are Red values used internally by some datatypes like `function!`, `object!` and derivative types. A context contains two consecutive tables, the first one is the list of word entries in the context represented as symbol references, the second is the associated values for each of the symbols in the first table. `length` field indicates the number of entries in the context. Context records can only exist at root level, they cannot be nested. If `no-values` flag is set, it means that there are no values following the symbols (empty context). If `stack?` flag is set, then the values are allocated on the stack instead of the heap memory. The `self?` flag is used to indicate that the context is able to handle a self-referencing word (`self` in objects).
+Contexts are Red values used internally by some datatypes like `function!`, `object!` and derivative types. A context record contains two consecutive lists, the first one is a list of word entries in the context represented as `symbol` references, the second one is the associated value records for each of the symbols in the first list.
 
-=== Word! anchor:word[] 
+`kind` field in record's header encodes context's type: `0` for global context, `1` for context of a function, and `2` for context of an object. Global context is never encoded explicitly, which means that only values of `1` and `2` are used. `length` field indicates the number of entries in the context.
+
+If `no-values` flag is set, it means that there are no value records following the symbols (empty context). If `stack?` flag is set, then the values are allocated on the stack instead of the heap memory. The `self?` flag is used to indicate that the context is able to handle a self-referencing word (`self` in objects).
+
+==== `word!` anchor:word[] 
 
 ----
-Default: header (4), symbol (4), context (4), index (4)
-Compact: TBD
+Default:  header (4), symbol (4), index (4), ...|context [object!|function!]
+Referral: header (4), symbol (4), index (4), context [reference]
+Compact:  TBD
 
 header/type=15
 header/set?=0|1
+header/reference?=0|1
 ----
 
-The `context` field is an offset from the beginning of the records section in the Redbin file referring to a `context!` value. The context needs to be located before the word record in the Redbin records list. If `context` equals `-1`, it refers to global context.
+`symbol` field is an index in Redbin <<Symbol table, symbol table>>. `index` is word's index in the context to which it is bound. If `set?` flag is set, then word is bound to a global context and `index` field is followed by a value record to which word needs to be set; otherwise `index` field is followed by either `object!` or `function!` record that contain context to which word needs to be bound.
 
-If the `set?` field is defined, this record is followed by an `any-value!` record, and the word will need to be set to that value (in the right context) by the decoder. This forms a name/value couple allowing to encode words' values in an adhoc way, when providing a sequence of values for a given context is too expensive (mostly for name/value couples in global context).
+NOTE: In current implementation, enabled `set?` flag indicates that word is bound to a global context, but value record is omitted.
 
-=== Set-word! anchor:set-word[] 
+==== `set-word!` anchor:set-word[] 
 
 ----
-Default: header (4), symbol (4), context (4), index (4)
-Compact: TBD
+Default:  header (4), symbol (4), index (4), ...|context [object!|function!]
+Referral: header (4), symbol (4), index (4), context [reference]
+Compact:  TBD
 
 header/type=16
+header/set?=0|1
+header/reference?=0|1
 ----
 
-Same as `word!`.
+Same encoding rules as <<word, `word!`>>.
 
-=== Lit-word! anchor:lit-word[] 
+==== `lit-word!` anchor:lit-word[] 
 
 ----
-Default: header (4), symbol (4), context (4), index (4)
-Compact: TBD
+Default:  header (4), symbol (4), index (4), ...|context [object!|function!]
+Referral: header (4), symbol (4), index (4), context [reference]
+Compact:  TBD
 
 header/type=17
+header/set?=0|1
+header/reference?=0|1
 ----
-Same as `word!`.
 
-=== Get-word! anchor:get-word[] 
+Same encoding rules as <<word, `word!`>>.
+
+==== `get-word!` anchor:get-word[] 
 
 ----
-Default: header (4), symbol (4), context (4), index (4)
-Compact: TBD
+Default:  header (4), symbol (4), index (4), ...|context [object!|function!]
+Referral: header (4), symbol (4), index (4), context [reference]
+Compact:  TBD
 
 header/type=18
+header/set?=0|1
+header/reference?=0|1
 ----
-Same as `word!`.
 
-=== Refinement! anchor:refinement[] 
+Same encoding rules as <<word, `word!`>>.
+
+==== `refinement!` anchor:refinement[] 
 
 ----
-Default: header (4), symbol (4), context (4), index (4)
-Compact: TBD
+Default:  header (4), symbol (4), index (4), ...|context [object!|function!]
+Referral: header (4), symbol (4), index (4), context [reference]
+Compact:  TBD
 
 header/type=19
+header/set?=0|1
+header/reference?=0|1
 ----
 
-Same as `word!`.
+Same encoding rules as <<word, `word!`>>.
 
-=== Issue! anchor:issue[] 
+==== `issue!` anchor:issue[] 
 
 ----
 Default: header (4), symbol (4)
@@ -465,126 +484,146 @@ Compact: TBD
 header/type=20
 ----
 
-=== Native! anchor:native[] 
+`symbol` field is an index in Redbin <<Symbol table, symbol table>>.
+
+==== `native!` anchor:native[] 
 
 ----
-Default: header (4), ID (4), spec [block!]
-Compact: TBD
+Default:  header (4), ID (4), spec [block!]
+Referral: header (4), ID (4), spec [reference]
+Compact:  TBD
 
 header/type=21
+header/reference?=0|1
 ----
 
-`ID` is an offset into the internal `natives/table` jump table.
+`ID` field is an offset into the internal `natives/table` jump table, followed by a `block!` record encoding native's spec.
 
-
-=== Action! anchor:action[] 
+==== `action!` anchor:action[] 
 
 ----
-Default: header (4), ID (4), spec [block!]
-Compact: TBD
+Default:  header (4), ID (4), spec [block!]
+Referral: header (4), ID (4), spec [reference]
+Compact:  TBD
 
 header/type=22
+header/reference?=0|1
 ----
 
-`ID` is an offset into the internal `actions/table` jump table.
+`ID` field is an offset into the internal `actions/table` jump table, followed by a `block!` record encoding action's spec.
 
-=== Op! anchor:op[] 
+==== `op!` anchor:op[] 
 
 ----
-Default: header (4), symbol (4), 
+Default: header (4), parent [function!]|spec [block!], ID (4)
 Compact: TBD
 
 header/type=23
+header/body?=0|1
+neader/native?=0|1
 ----
 
-`symbol` represents the action, native or function name (only from global context) used as the source for that `op!` value. 
+If `body?` flag is set, it indicates that `op!` is derived from a `function!`;  if `body?` flag is not set, then `op!` is derived from either `action!` or `native!` -- the choice between the two is indicated by `native?` flag.
 
+If `body?` flag is set, then `header` field is followed by a `function!` record that encodes `op!` value's parent. Otherwise it is followed by a `block!` record encoding `op!` value's spec, and then by an `ID` of either `action!` or `native!` value.
 
-=== Function! anchor:function[] 
+==== `function!` anchor:function[] 
 
 ----
-Default: header (4), context [context!], spec [block!], body [block!], args [block!], obj-ctx [context!]
-Compact: TBD
+Default:  header (4), spec-size (4), body-size (4), context [context!], spec [block!], body [block!]
+Referral: header (4), context [reference]
+Compact:  TBD
 
 header/type=24
+header/reference?=0|1
 ----
 
-=== Path! anchor:path[] 
+`spec-size` and `body-size` speicfy sizes of `spec` and `body` blocks, respectively, and are used for pre-allocation by decoder.
+
+Target of the reference is either `function!`, `op!`, or `any-word!`; `function!` value (loaded value, parent of `op!`, or context of `any-word!`) is copied over verbatim, which means that referral shares with it not only binding information, but also spec and body blocks.
+
+==== `path!` anchor:path[] 
 
 ----
-Default: header (4), head (4), length (4), ...
-Compact: TBD
+Default:  header (4), head (4), length (4), ... * length
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=25
+header/reference?=0|1
 ----
 
-Same encoding rules as `block!`.
+Same encoding rules as <<block, `block!`>>.
 
-=== Lit-path! anchor:lit-path[] 
+==== `lit-path!` anchor:lit-path[] 
 
 ----
-Default: header (4), head (4), length (4), ...
-Compact: TBD
+Default:  header (4), head (4), length (4), ... * length
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=26
+header/reference?=0|1
 ----
 
-Same encoding rules as `block!`.
+Same encoding rules as <<block, `block!`>>.
 
-=== Set-path! anchor:set-path[] 
+==== `set-path!` anchor:set-path[] 
 
 ----
-Default: header (4), head (4), length (4), ...
-Compact: TBD
+Default:  header (4), head (4), length (4), ... * length
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=27
+header/reference?=0|1
 ----
 
-Same encoding rules as `block!`.
+Same encoding rules as <<block, `block!`>>.
 
-=== Get-path! anchor:get-path[] 
+==== `get-path!` anchor:get-path[] 
 
 ----
-Default: header (4), head (4), length (4), ...
-Compact: TBD
+Default:  header (4), head (4), length (4), ... * length
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=28
+header/reference?=0|1
 ----
 
-Same encoding rules as `block!`.
+Same encoding rules as <<block, `block!`>>.
 
-=== Bitset! anchor:bitset[] 
+==== `bitset!` anchor:bitset[] 
 
 ----
-Default: header (4), length (4), bits (length)
-Compact: TBD
+Default:  header (4), length (4), data (length), padding (1-3)
+Referral: header (4), buffer [reference]
+Compact:  TBD
 
 header/type=30
+header/complement?=0|1
 ----
 
-The `length` fields indicates the number of bits stored, rounded to the upper multiple of 8. The bits are memory dumps of the `bitset!` series buffer. Byte order is preserved. `bits` field needs to be padded with enough NUL bytes to keep the next record 32-bit aligned.
+If `complement?` flag is set, it indicates that bitset is complemented. The `length` field encodes the number of bytes stored. `data` is a memory dump of `bitset!` series buffer, byte order is preserved. `data` field needs to be padded with enough NUL bytes to keep the next record aligned at 32-bit boundary.
 
-=== Point! anchor:point[] 
+= TBD
 
-----
-Default: header (4), x (4), y (4), z (4)
-Compact: TBD
-
-header/type=31
-----
-
-=== Object! anchor:object[] 
+==== `object!` anchor:object[] 
 
 ----
-Default: header (4), context [reference!], class-id (4), on-set-idx (4), on-set-arity (4)
-Compact: TBD
+Default:  header (4), class (4), on-set (4), arity (4), context [context!]
+Referral: header (4), context [reference]
+Compact:  TBD
 
 header/type=32
+header/owner?=0|1
+header/reference?=0|1
 ----
 
-The `on-set-idx` field indicates the offset of the `on-change*` in the context values table. The `on-set-arity` stores the arity of that function.
+`on-set` and `arity` are optional.
 
-=== Typeset! anchor:typeset[] 
+==== `typeset!` anchor:typeset[] 
 
 ----
 Default: header (4), array1 (4), array2 (4), array3 (4)
@@ -593,27 +632,31 @@ Compact: TBD
 header/type=33
 ----
 
-=== Error! anchor:error[] 
+==== `error!` anchor:error[] 
 
 ----
-Default: header (4), context [reference!]
+Default: header (4), code (4), ... * 6
 Compact: TBD
 
 header/type=34
 ----
 
-=== Vector! anchor:vector[] 
+`arg1 arg2 arg3 near where stack`
+
+==== `vector!` anchor:vector[] 
 
 ----
-Default: header (4), head (4), length (4), values (unit*length)
-Compact: TBD
+Default:  header (4), head (4), length (4), type (4), data (unit * length), padding (1-3)
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=35
+header/unit=1|2|4|8
 ----
 
-`unit` indicates the size of the vector element type size: 1, 2, 4 or 8 bytes. The `values` field holds the list of values. `values` needs to be padded with NUL bytes to align the next record to a 32-bit boundary (if `unit` is equal to 1 or 2).
+`unit` indicates the size of the vector element type size: 1, 2, 4 or 8 bytes. The `data` field holds the list of values. Needs to be padded with NUL bytes to align the next record to a 32-bit boundary (if `unit` is equal to 1 or 2).
 
-=== Pair! anchor:pair[] 
+==== `pair!` anchor:pair[] 
 
 ----
 Default: header (4), x (4), y (4)
@@ -622,18 +665,18 @@ Compact: TBD
 header/type=37
 ----
 
-=== Percent! anchor:percent[] 
+==== `percent!` anchor:percent[] 
 
 ----
-Default: [padding=0 (4),] header (4), value (8)
+Default: padding [padding], header (4), value (8)
 Compact: TBD
 
 header/type=38
 ----
 
-Percent value is stored as a 64-bit float. The optional padding field is added to properly align the `value` field offset to a 64-bit boundary.
+Same encoding rules as <<float, `float!`>>.
 
-=== Tuple! anchor:tuple[] 
+==== `tuple!` anchor:tuple[] 
 
 ----
 Default: header (4), array1 (4), array2 (4), array3 (4)
@@ -642,64 +685,70 @@ Compact: TBD
 header/type=39
 ----
 
-=== Map! anchor:map[] 
+==== `map!` anchor:map[] 
 
 ----
-Default: header (4), length (4), ...
-Compact: TBD
+Default:  header (4), length (4), ... * length
+Referral: header (4), buffer [reference]
+Compact:  TBD
 
 header/type=40
+header/reference?=0|1
 ----
 
 The `length` field contains the number of elements (keys + values) to be stored in the map. The map elements simply follow the length definition, no separator or end delimiter is required.
 
-=== Binary! anchor:binary[] 
+==== `binary!` anchor:binary[] 
 
 ----
-Default: header (4), head (4), length (4), ...
-Compact: TBD
+Default:  header (4), head (4), length (4), data (length)
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=41
+header/reference?=0|1
 ----
 
-Same encoding rules as `block!`.
-
-=== Time! anchor:time[] 
+==== `time!` anchor:time[] 
 
 ----
-Default: [padding=0 (4),] header (4), value (8)
+Default: padding [padding], header (4), value (8)
 Compact: TBD
 
 header/type=43
 ----
 
-Time value is stored as a 64-bit float. The optional padding field is added to properly align the `value` field offset to a 64-bit boundary.
+Same encoding rules as <<float, `float!`>>.
 
-=== Tag! anchor:tag[] 
+==== `tag!` anchor:tag[] 
 
 ----
-Default: header (4), head (4), length (4), data (unit*length)
-Compact: TBD
+Default:  header (4), head (4), length (4), data (unit * length), padding (1-3)
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=44
 header/unit=1|2|4
+header/reference?=0|1
 ----
 
-Same encoding rules as `string!`.
+Same encoding rules as <<string, `string!`>>.
 
-=== Email! anchor:email[] 
+==== `email!` anchor:email[] 
 
 ----
-Default: header (4), head (4), length (4), data (unit*length)
-Compact: TBD
+Default:  header (4), head (4), length (4), data (unit * length), padding (1-3)
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=45
 header/unit=1|2|4
+header/reference?=0|1
 ----
 
-Same encoding rules as `string!`.
+Same encoding rules as <<string, `string!`>>.
 
-=== Date! anchor:date[] 
+==== `date!` anchor:date[] 
 
 ----
 Default: header (4), date (4), time (8)
@@ -710,7 +759,7 @@ header/type=47
 
 Date is packed into a 32-bit integer (same as in `red-date!`). Time value is stored as a 64-bit float.
 
-=== Money! anchor:money[] 
+==== `money!` anchor:money[] 
 
 ----
 Default: header (4), currency (1), amount (11)
@@ -722,17 +771,30 @@ header/sign=0|1
 
 `amount` is a sequence of nibbles representing the money integral and decimal part (22 digits) in network byte order. If `sign` is set, the amount is interpreted as negative. `currency` is an integer value (0 for generic money, < 255 for existing currency code).
 
-=== Ref! anchor:ref[]
+==== `ref!` anchor:ref[]
 
 ----
-Default: header (4), head (4), length (4), data (unit*length)
-Compact: TBD
+Default:  header (4), head (4), length (4), data (unit * length), padding (1-3)
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
 
 header/type=50
 header/unit=1|2|4
+header/reference?=0|1
 ----
 
-Same encoding rules as `string!`.
+Same encoding rules as <<string, `string!`>>.
+
+==== `image!` anchor:image[]
+
+----
+Default:  header (4), head (4), length (4), rgba (4 * length)
+Referral: header (4), head (4), buffer [reference]
+Compact:  TBD
+
+header/type=51
+header/reference?=0|1
+----
 
 == Redbin codec
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -2,15 +2,11 @@
 :toc:
 :numbered:
 
-_Specification version 1_
+_Specification version 2_
 
 Redbin is a binary format that accurately represents Red values stored in memory, while enabling fast loading (avoiding the parsing and validation stage of the text representation format). Redbin format is largely inspired by http://www.rebol.com/article/0044.html[REBin]. Redbin can encode binding information for words and can handle cycles in `any-block!` values.
 
-The user interface for Redbin format access will be provided by `load/binary` and `mold/binary`. Underlying implementation _could_ use the codec sub-system, once available.
-
-Implementation constraints:
-
-* Base address in memory of Redbin data about to be loaded, needs to be 64-bit aligned.
+The user interface for Redbin format access is provided via codec sub-system. See <<Redbin codec>> section for details _TBD_.
 
 == Encoding format
 
@@ -572,3 +568,7 @@ header/type=255
 ----
 
 This special record type stores a reference to an already loaded value of type `any-block!` or `object!`. This makes it possible to store cycles in Redbin. The reference is created from a path into the loaded values (assuming that the root values are stored in a block). Each `index` field points to the series or object value to go into, until the last one is reached, pointing to the value to refer to. The `count` field indicates the number of indexes to go through. If one of the indexes has to be applied to an object, it refers to the corresponding object's field (0 => 1st field, 1 => 2nd field,...). All indexes are zero-based.
+
+== Redbin codec
+
+_TBD_

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -64,16 +64,72 @@ After the Symbol Table, Red values are stored as records in sequence with no spe
 
 Each records starts with a 32-bit `header` field defined as:
 
-****
- * bit31    : new-line flag
- * bit30    : no-values flag (for contexts)
- * bit29    : stack? flag    (for contexts)
- * bit28    : self? flag     (for contexts)
- * bit27    : set? flag      (for words)
- * bit26-16 : <reserved>
- * bit15-8  : unit (used for encoding elements size in a series buffer)
- * bit7-0   : type
-****
+.Header flags.
+[options="header" cols="1,3,2"]
+|===
+| Bits | Description | Relevant datatypes
+
+| 31
+| `new-line` flag; if set, indicates the presence of new-line flag in value slot.
+| All.
+
+| 30
+| `no-values` flag; if set, indicates that `context!` record does not contain value records.
+| `context!`
+
+| 29
+| `stack?` flag; if set, indicates that values of a decoded `context!` are allocated on data stack.
+| `context!`
+
+| 28
+| `self?` flag; if set, indicates that decoded `context!` is capable of self-referencing via `self` word.
+| `context!`
+
+| 27-26
+| Context type.
+| `context!`
+
+| 25
+| `set?` flag; if set, indicates that `any-word!` records is followed by value record to which decoded `any-word!` needs to be set. _TBD In current implementation this is disabled, and flag instead indicates that word is bound to a global context._
+| `any-word!`
+
+| 24
+| `owner?` flag; if set, indicates that decoded `object!` owns one or more values.
+| `object!`
+
+| 23
+| `native?` flag; if set, indicates that decoded `op!` value is derived from `native!`, else from `action!`.
+| `op!`
+
+| 22
+| `body?` flag; if set, indicates that `op!` values is derived from either `function!` or `routine!` and has a body block.
+| `op!`
+
+| 21
+| `complement?` flag; if set, indicates that decoded `bitset!` value is complemented.
+| `bitset!`
+
+| 20
+| `sign` flag; if set, indicates that decoded `money!` value has a negative sign.
+| `money!`
+
+| 19
+| Redbin record contains a reference __TBD link to section__.
+| __TBD list datatypes__ `series!`, `any-function!`..?
+
+| 18-16
+| Reserved for future use.
+| --
+
+| 15-8
+| Unit type, encoded element size in a series buffer.
+| `series!`
+
+| 7-0
+| Value type.
+| All.
+
+|===
 
 Here follows the description of each individual record:
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -38,7 +38,7 @@ WARNING: Attempt to `load` Redbin data with malformed payload will likely lead t
 
 == Lexical conventions
 
-A number of semi-formal lexical conventions are used throughout this document to describe the Redbin encoding format:
+Several semi-formal lexical conventions are used throughout this document to describe the Redbin encoding format:
 
 * Numbers in parentheses indicate field's size;
 * Field followed by an equal sign has a fixed content;
@@ -70,10 +70,10 @@ Redbin data starts with a header having the following format:
 magic="REDBIN" (6), version=1|2 (1), flags (1), length (4), size (4)
 
 length : number of root records to load.
-size   : size of records payload in bytes.
+size   : the size of records payload in bytes.
 ----
 
-Layout of `flags` field is described in the table below.
+The layout of `flags` field is described in the table below.
 
 .Redbin header flags.
 [options="header" cols="1,9"]
@@ -87,22 +87,22 @@ Layout of `flags` field is described in the table below.
 | If set, indicates that Redbin data contains a <<Symbol table, symbol table>>.
 
 | 1
-| If set, indicates that data immidiately following `flags` field is compressed. Compression algorithm is implementation-dependent.
+| If set, indicates that data immediately following the `flags` field is compressed. The compression algorithm is implementation-dependent.
 
 | 0
-| If set, indicates that records section is encoded using the compact format.
+| If set, indicates that the records section is encoded using the compact format.
 
 |===
 
-Header is the only mandatory section in Redbin format encoding; both <<Symbol table, symbol table>> and <<Records definitions, payload>> can be ommitted, provided that relevant flags and fields a properly specified.
+The header is the only mandatory section in Redbin format encoding; both <<Symbol table, symbol table>> and <<Records definitions, payload>> can be omitted, provided that relevant flags and fields a properly specified.
 
 == Symbol table
 
 The symbol table immediately follows the header data. It is optional and should only be used if `any-word!` values are present in the <<Records definitions, Redbin payload>>. The symbol table has two sections:
 
-Offsets table:: A list of offsets to string representation of each symbol inside the strings buffer;
+Offsets table:: A list of offsets to a string representation of each symbol inside the strings buffer;
 
-Strings buffer:: Immidiately follows offsets table; contains UTF-8 encoded, NUL-terminated strings concatenated to each other, with an optional 64-bit boundary padding at the end of each string.
+Strings buffer:: Immediately follows offsets table; contains UTF-8 encoded, NUL-terminated strings concatenated to each other, with an optional 64-bit boundary padding at the end of each string.
 
 The position of an offset in the table is its _index_ (zero-based), which is used as a reference by symbols in `context!` and  `any-word!` records. The offsets in the table are offsets in bytes from the beginning of the strings buffers section to the referred string.
 
@@ -115,7 +115,7 @@ Compact: TBD
 
 `length` field contains the number of entries in the table. `size` field indicates the size of the strings buffer in bytes (including optional padding).
 
-During the runtime booting process, these symbols are merged within Red's own symbol table and the offsets are replaced by the symbol ID values from that table. <<Redbin codec, Runtime codec>> omits this merging stage and instantiates symbols in-place for each relevant decoded record.
+During the runtime booting process, these symbols are merged with Red's symbol table and the offsets are replaced by the symbol ID values from that table. <<Redbin codec, Runtime codec>> omits this merging stage and instantiates symbols in-place for each relevant decoded record.
 
 After the symbol table, Red values are stored as a sequence of records, with no special delimiters or end markers. The loaded values from the root level are stored in a `block!` series.
 
@@ -129,7 +129,7 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 | Bits | Description | Relevant datatypes
 
 | 31
-| `new-line` flag; if set, indicates the presence of new-line flag in value slot.
+| `new-line` flag; if set, indicates the presence of a new-line flag in value slot.
 | All.
 
 | 30
@@ -149,7 +149,7 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 | `context!`
 
 | 25
-| `set?` flag; if set, indicates that `any-word!` records is followed by value record to which decoded `any-word!` needs to be set.
+| `set?` flag; if set, indicates that `any-word!` record is followed by value record to which decoded `any-word!` needs to be set.
 | `any-word!`
 
 | 24
@@ -161,7 +161,7 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 | `op!`
 
 | 22
-| `body?` flag; if set, indicates that `op!` values is derived from either `function!` or `routine!` and has a body block.
+| `body?` flag; if set, indicates that `op!` value is derived from either `function!` or `routine!` and has a body block.
 | `op!`
 
 | 21
@@ -190,7 +190,7 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 
 |===
 
-Here follows individual descriptions of each type of record.
+Here follow individual descriptions of each type of record.
 
 === Special
 
@@ -220,13 +220,13 @@ Reference records are used to encode various relations between Red values, such 
 
 `length` field specifies the number of `offset` fields contained inside a reference record; each `offset` field specifies a zero-based offset to an already loaded Red value thru its parent, starting from the root block. A list of such offsets effectively forms a path to a referenced value.
 
-Red value that is used as a parent to calculate offset into is called a _waypoint_; Red value to which the path is formed by a reference is called an _target_. Reference records are usually used by other value records in order to obtain datatype-specific parts that they share with the target. Red value record that contains a reference is called a _referral_. In all record definitions that follow, referral format is used to describe such form of encoding, which is used only when `reference?` header flag of a respective value record is set.
+Red value that is used as a parent to calculate offset into is called a _waypoint_; Red value to which the path is formed by a reference is called a _target_. Reference records are usually used by other value records to obtain datatype-specific parts that they share with the target. Red value record that contains a reference is called a _referral_. In all record definitions that follow, referral format is used to describe such a form of encoding, which is used only when `reference?` header flag of a respective value record is set.
 
 Redbin records that can act as referrals are: `series!`, `map!`, `bitset!`, `any-word!`, `refinement!`, `object!`, `function!`.
 
 Only a selected number of datatypes can be a waypoint or a target, and rules of offset calculation and referencing for each of them are described in the table below.
 
-.Datatypes thru which reference paths can be formed.
+.Datatypes thru and to which reference paths can be formed.
 [options="header" cols="1,2,2"]
 |===
 | Datatypes | Waypoint | Target
@@ -261,11 +261,11 @@ Only a selected number of datatypes can be a waypoint or a target, and rules of 
 
 |===
 
-Referral can target its own parent, in such case a cycle is formed.
+A referral can target its parent, in such case a cycle is formed.
 
 === Unsupported
 
-A number of Red value datatypes listed below are not supported by Redbin format.
+Some Red value datatypes (listed below) are not supported by Redbin format.
 
 .Red datatypes not supported by Redbin format.
 [options="header" cols="1,3"]
@@ -342,7 +342,7 @@ header/type=5
 header/reference?=0|1
 ----
 
-The `head` field indicates a zero-based offset of the index position from block's head. The `length` field contains the number of values to be stored in the block. The block values' records then follow the `length` field.
+The `head` field indicates a zero-based offset of the index position from the block's head. The `length` field contains the number of values to be stored in the block. The block values' records then follow the `length` field.
 
 ==== `paren!` anchor:paren[] 
 
@@ -369,7 +369,7 @@ header/unit=1|2|4
 header/reference?=0|1
 ----
 
-The `head` field has same meaning as for other series values. The `unit` field indicates the encoding format of the string, only values of 1, 2 and 4 are valid. The `length` field contains the number of codepoints to be stored in the string, up to 16777215 codepoints (2^24^ - 1) are supported. The string is encoded in either UCS-1, UCS-2 or UCS-4 format, depending on the maximum width of contained codepoints. No NUL-terminating character is present in `data`, nor accounted for in the `length` field. An optional tail padding of 1 to 3 NUL bytes can be present to align the end of the `string!` record with the 32-bit boundary.
+The `head` field has the same meaning as in other series records. The `unit` field indicates the encoding format of the string, only values of 1, 2, and 4 are valid. The `length` field contains the number of codepoints to be stored in the string, up to 16777215 codepoints (2^24^ - 1) are supported. The string is encoded in either UCS-1, UCS-2 or UCS-4 format, depending on the maximum width of contained codepoints. No NUL-terminating character is present in `data`, nor accounted for in the `length` field. An optional tail padding of 1 to 3 NUL bytes can be present to align the end of the `string!` record with a 32-bit boundary.
 
 ==== `file!` anchor:file[] 
 
@@ -430,7 +430,7 @@ Compact: TBD
 header/type=12
 ----
 
-An optional `padding` field is added to properly align the `value` field at 64-bit boundary. `value` field itself contains a 64-bit https://en.wikipedia.org/wiki/IEEE_754[IEEE 754] floating-point numeral.
+An optional `padding` field is added to properly align the `value` field at a 64-bit boundary. `value` field itself contains a 64-bit https://en.wikipedia.org/wiki/IEEE_754[IEEE 754] floating-point numeral.
 
 ==== `context!` anchor:context[] 
 
@@ -447,9 +447,9 @@ header/self?=0|1
 
 Contexts are Red values used internally by some datatypes like `function!`, `object!` and derivative types. A context record contains two consecutive lists, the first one is a list of word entries in the context represented as `symbol` references, the second one is the associated value records for each of the symbols in the first list.
 
-`kind` field in record's header encodes context's type: `0` for global context, `1` for context of a function, and `2` for context of an object. Global context is never encoded explicitly, which means that only values of `1` and `2` are used. `length` field indicates the number of entries in the context.
+`kind` field in record's header encodes context's type: `0` for global context, `1` for the context of a function, and `2` for the context of an object. The global context is never encoded explicitly, which means that only values of `1` and `2` are used. `length` field indicates the number of entries in the context.
 
-If `no-values` flag is set, it means that there are no value records following the symbols (empty context). If `stack?` flag is set, then the values are allocated on the stack instead of the heap memory. The `self?` flag is used to indicate that the context is able to handle a self-referencing word (`self` in objects).
+If `no-values` flag is set, it means that there are no value records following the symbols (empty context). If `stack?` flag is set, then the values are allocated on the stack instead of the heap memory. The `self?` flag is used to indicate that the context can handle a self-referencing word (`self` in objects).
 
 ==== `word!` anchor:word[] 
 
@@ -463,9 +463,9 @@ header/set?=0|1
 header/reference?=0|1
 ----
 
-`symbol` field is an index in Redbin <<Symbol table, symbol table>>. `index` is word's index in the context to which it is bound. If `set?` flag is set, then word is bound to a global context and `index` field is followed by a value record to which word needs to be set; otherwise `index` field is followed by either `object!` or `function!` record that contain context to which word needs to be bound.
+`symbol` field is an index in Redbin <<Symbol table, symbol table>>. `index` is word's index in the context to which it is bound. If `set?` flag is set, then word is bound to a global context and `index` field is followed by a value record to which word needs to be set; otherwise `index` field is followed by either `object!` or `function!` record that contains context to which word needs to be bound.
 
-NOTE: In current implementation, enabled `set?` flag indicates that word is bound to a global context, but value record is omitted.
+NOTE: In the current implementation, enabled `set?` flag indicates that word is bound to a global context, but value record is omitted.
 
 ==== `set-word!` anchor:set-word[] 
 
@@ -569,7 +569,7 @@ neader/native?=0|1
 
 If `body?` flag is set, it indicates that `op!` is derived from a `function!`;  if `body?` flag is not set, then `op!` is derived from either `action!` or `native!` -- the choice between the two is indicated by `native?` flag.
 
-If `body?` flag is set, then `header` field is followed by a `function!` record that encodes `op!` value's parent. Otherwise it is followed by a `block!` record encoding `op!` value's spec, and then by an `ID` of either `action!` or `native!` value.
+If `body?` flag is set, then `header` field is followed by a `function!` record that encodes `op!` value's parent. Otherwise, it is followed by a `block!` record encoding `op!` value's spec, and then by an `ID` of either `action!` or `native!` value.
 
 ==== `function!` anchor:function[] 
 
@@ -582,9 +582,9 @@ header/type=24
 header/reference?=0|1
 ----
 
-`spec-size` and `body-size` speicfy sizes of `spec` and `body` blocks, respectively, and are used for pre-allocation by decoder.
+`spec-size` and `body-size` specify sizes of `spec` and `body` blocks, respectively, and are used for pre-allocation by the decoder.
 
-Target of the reference is either `function!`, `op!`, or `any-word!`; `function!` value (loaded value, parent of `op!`, or context of `any-word!`) is copied over verbatim, which means that referral shares with it not only binding information, but also spec and body blocks.
+The target of the reference is either `function!`, `op!`, or `any-word!`; `function!` value (loaded value, parent of `op!`, or context of `any-word!`) is copied over verbatim, which means that referral shares with it not only binding information, but also spec and body blocks.
 
 ==== `path!` anchor:path[] 
 
@@ -649,7 +649,7 @@ header/type=30
 header/complement?=0|1
 ----
 
-If `complement?` flag is set, it indicates that bitset is complemented. The `length` field encodes the number of bytes stored. `data` is a memory dump of `bitset!` series buffer, byte order is preserved. `data` field needs to be padded with enough NUL bytes to keep the next record aligned at 32-bit boundary.
+If `complement?` flag is set, it indicates that bitset is complemented. The `length` field encodes the number of bytes stored. `data` is a memory dump of `bitset!` series buffer, byte order is preserved. `data` field needs to be padded with enough NUL bytes to keep the next record aligned at a 32-bit boundary.
 
 ==== `object!` anchor:object[] 
 
@@ -663,7 +663,7 @@ header/owner?=0|1
 header/reference?=0|1
 ----
 
-`class` field stores object's class ID. `on-set` field is a pair of 16-bit integers, each of which encodes an offset to `on-change*` and `on-deep-change*` function in object's values block. `arity` field has the same format as `on-set`, but encodes arities of the respective functions. These two fields are optional and are encoded only if `owner?` flags is set in record's header.
+`class` field stores object's class ID. `on-set` field is a pair of 16-bit integers, each of which encodes an offset to `on-change*` and `on-deep-change*` function in object's values block. `arity` field has the same format as `on-set`, but encodes arities of the respective functions. These two fields are optional and are encoded only if `owner?` flag is set in record's header.
 
 ==== `typeset!` anchor:typeset[] 
 
@@ -674,7 +674,7 @@ Compact: TBD
 header/type=33
 ----
 
-`array1`, `array2` and `array3` fields form a a bitset where index of each `1` bit indicates a datatype ID contained inside a typeset.
+`array1`, `array2`, and `array3` fields form a bitset where an index of each `1` bit indicates a datatype ID contained inside a typeset.
 
 ==== `error!` anchor:error[] 
 
@@ -698,7 +698,7 @@ header/type=35
 header/unit=1|2|4|8
 ----
 
-`type` field contain datatype ID of vector's element. `unit` field indicates the size of the vector element's type size in bytes. Only the following combinations of `type` and `unit` values are supported:
+`type` field contains datatype ID of vector's element. `unit` field indicates the size of the vector element's type size in bytes. Only the following combinations of `type` and `unit` values are supported:
 
 .Combinations of `vector!` fields.
 [options="header" cols="1,1"]
@@ -716,7 +716,7 @@ header/unit=1|2|4|8
 
 |===
 
-The `data` field holds the list of values. If `unit` is equal to 1 or 2, `data` needs to be padded with NUL bytes up to a 32-bit boundary.
+The `data` field holds a list of values. If `unit` is equal to 1 or 2, `data` needs to be padded with NUL bytes up to a 32-bit boundary.
 
 ==== `pair!` anchor:pair[] 
 
@@ -750,7 +750,7 @@ header/type=39
 header/unit=3-12
 ----
 
-`unit` field encodes tuple's size in bytes; only values from `3` to `12` are allowed. `array1`, `array2` and `array3` fields together form a memory dump of tuple's slot payload.
+`unit` field encodes tuple's size in bytes; only values from `3` to `12` are allowed. `array1`, `array2`, and `array3` fields together form a memory dump of tuple's slot payload.
 
 ==== `map!` anchor:map[] 
 
@@ -872,32 +872,3 @@ header/reference?=0|1
 ----
 
 `length` field is a pair of 16-bit integers encoding width and height of an image. `rgba` field contains RGBA content of an image (4 bytes per pixel) with preserved byte order.
-
-== Redbin codec
-
-Redbin format enables use-cases typically associated with data serialization, such as:
-
-* Persistent state and image-based environments;
-* Remote procedure calls;
-* Sharing data and programs over the network with other systems;
-* Detecting changes in time-varying data.
-
-To make these use-cases possible, an interface to Redbin format is provided via codec sub-system. Redbin codec can be acessed with `save` and `load` functions as described below.
-
-*Syntax*
-----
-save/as <where> <value> 'redbin
-save <file> <value>
-
-load/as <data> 'redbin
-load <file>
-
-<data>  : Redbin-encoded binary! value
-<value> : value of any supported datatype
-<where> : saving destination for encoded data; file!, url!, string!, binary!, none!
-<file>  : file! with .redbin extension
-----
-
-NOTE: Redbin codec cannot encode or decode <<Unsupported, unsupported>> values or values that contain them.
-
-WARNING: Attempt to `load` a Redbin data with malformed payload will likely lead to unexpected results or a runtime crash.

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -206,7 +206,15 @@ Only a selected number of datatypes can be a waypoint or a target, and rules of 
 
 | `any-block!`, `map!`
 | An offset from the series' head. `map!` is treated as a linear block.
-| Buffer is reused.
+| Series buffer is reused.
+
+| `any-string!`, `binary!`, `bitset!`, `vector!`, `image!`
+| --
+| Series buffer is reused.
+
+| `action!`, `native!`
+| Offset from the head of the spec block.
+| Spec buffer is reused.
 
 | `object!`
 | An offset from the head of the values block.
@@ -215,10 +223,6 @@ Only a selected number of datatypes can be a waypoint or a target, and rules of 
 | `any-word!`, `refinement!`
 | An offset into a context to which value is bound, which is represented as either `object!` or `function!` value.
 | Binding information is reused.
-
-| `action!`, `native!`
-| Offset from the head of the spec block.
-| Spec buffer is reused.
 
 | `function!`
 | Offset of value `0` selects a spec block, offset of value `1` selects a body block. Other offset values are forbidden.
@@ -229,8 +233,6 @@ Only a selected number of datatypes can be a waypoint or a target, and rules of 
 | Binding information of `function!` value from which `op!` is derived is reused.
 
 |===
-
-NOTE: TBD the rest of datatypes that can be only targets... or just limit the description to waypoints only and generally state which parts in targets of what datatype are reused (either binding, buffers of spec/body blocks).
 
 Referral can reference its own parent, in such case a cycle is formed.
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -11,18 +11,15 @@ The user interface for Redbin format access is provided via codec sub-system. Se
 
 == Lexical conventions
 
-NOTE: TBD.
+A number of semi-formal lexical conventions are used throughout this document to describe the Redbin encoding format:
 
-A number of lexical conventions are used throughout this document to describe the Redbin encoding format:
-
-* ()
-* =
-* []
-* ...
-* |
-* x * y
-* Path notation.
-* Signed/unsigned sizes and such. Decimal numbers.
+* Numbers in parentheses indicate field's size;
+* Field followed by an equal sign has a fixed content;
+* Field followed by a name of a record type enclosed in square brackets indicates an encoded Redbin record of that type; 
+* Ellipsis stands for a generic Redbin value record of any datatype;
+* Pipe symbol indicates a choice between alternatives;
+* Multiplication sign indicates a repetition;
+* Path notation is used to refer to record's header flags.
 
 == Encoding format
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -1,12 +1,28 @@
 = Redbin format
 :toc:
+:toclevels: 3
 :numbered:
 
-_Specification version 2_
+NOTE: Specification version 2.
 
-Redbin is a binary format that accurately represents Red values stored in memory, while enabling fast loading (avoiding the parsing and validation stage of the text representation format). Redbin format is largely inspired by http://www.rebol.com/article/0044.html[REBin]. Redbin can encode binding information for words and can handle cycles in `any-block!` values.
+Redbin is a binary format that accurately represents Red values stored in memory while enabling fast loading (avoiding the parsing and validation stage of the text representation format). Redbin format is largely inspired by http://www.rebol.com/article/0044.html[REBin]; it can encode binding information for `any-word!` values, references to shared buffers for `series!` values, and can handle arbitrary cycles for `any-block!` values.
 
-The user interface for Redbin format access is provided via codec sub-system. See <<Redbin codec>> section for details _TBD_.
+The user interface for Redbin format access is provided via codec sub-system. See <<Redbin codec>> section for more details.
+
+== Lexical conventions
+
+NOTE: TBD.
+
+A number of lexical conventions are used throughout this document to describe the Redbin encoding format:
+
+* ()
+* =
+* []
+* ...
+* |
+* x * y
+* Path notation.
+* Signed/unsigned sizes and such. Decimal numbers.
 
 == Encoding format
 
@@ -701,7 +717,7 @@ Default: header (4), currency (1), amount (11)
 Compact: TBD
 
 header/type=49
-header/sign=1|0 (bit 14)
+header/sign=0|1
 ----
 
 `amount` is a sequence of nibbles representing the money integral and decimal part (22 digits) in network byte order. If `sign` is set, the amount is interpreted as negative. `currency` is an integer value (0 for generic money, < 255 for existing currency code).
@@ -717,17 +733,6 @@ header/unit=1|2|4
 ----
 
 Same encoding rules as `string!`.
-
-=== Reference! anchor:reference[] 
-
-----
-Default: header (4), count (4), index1 (4), index2 (4), ...
-Compact: TBD
-
-header/type=255
-----
-
-This special record type stores a reference to an already loaded value of type `any-block!` or `object!`. This makes it possible to store cycles in Redbin. The reference is created from a path into the loaded values (assuming that the root values are stored in a block). Each `index` field points to the series or object value to go into, until the last one is reached, pointing to the value to refer to. The `count` field indicates the number of indexes to go through. If one of the indexes has to be applied to an object, it refers to the corresponding object's field (0 => 1st field, 1 => 2nd field,...). All indexes are zero-based.
 
 == Redbin codec
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -198,7 +198,7 @@ Reference records are used to encode various relations between Red values, such 
 
 Red value that is used as a parent to calculate offset into is called a _waypoint_; Red value to which the path is formed by a reference is called an _target_. Reference records are usually used by other value records in order to obtain datatype-specific parts that they share with the target. Red value record that contains a reference is called a _referral_. In all record definitions that follow, referral format is used to describe such form of encoding, which is used only when `reference?` header flag of a respective value record is set.
 
-Redbin records that can act as referrals are: `series!`, `map!`, `bitset!`, `any-word!`, `refinement!`, `object!`, `native!`, `action!`, `function!`.
+Redbin records that can act as referrals are: `series!`, `map!`, `bitset!`, `any-word!`, `refinement!`, `object!`, `function!`.
 
 Only a selected number of datatypes can be a waypoint or a target, and rules of offset calculation and referencing for each of them are described in the table below.
 
@@ -233,7 +233,15 @@ Only a selected number of datatypes can be a waypoint or a target, and rules of 
 
 |===
 
+NOTE: TBD the rest of datatypes that can be only targets... or just limit the description to waypoints only and generally state which parts in targets of what datatype are reused (either binding, buffers of spec/body blocks).
+
 Referral can reference its own parent, in such case a cycle is formed.
+
+=== Unsupported
+
+NOTE: TBD.
+
+`routine!`, `ops!` derived from `routine!`, `handle!`, `event!`...
 
 === Datatypes
 
@@ -489,12 +497,10 @@ header/type=20
 ==== `native!` anchor:native[] 
 
 ----
-Default:  header (4), ID (4), spec [block!]
-Referral: header (4), ID (4), spec [reference]
-Compact:  TBD
+Default: header (4), ID (4), spec [block!]
+Compact: TBD
 
 header/type=21
-header/reference?=0|1
 ----
 
 `ID` field is an offset into the internal `natives/table` jump table, followed by a `block!` record encoding native's spec.
@@ -502,12 +508,10 @@ header/reference?=0|1
 ==== `action!` anchor:action[] 
 
 ----
-Default:  header (4), ID (4), spec [block!]
-Referral: header (4), ID (4), spec [reference]
-Compact:  TBD
+Default: header (4), ID (4), spec [block!]
+Compact: TBD
 
 header/type=22
-header/reference?=0|1
 ----
 
 `ID` field is an offset into the internal `actions/table` jump table, followed by a `block!` record encoding action's spec.
@@ -607,8 +611,6 @@ header/complement?=0|1
 
 If `complement?` flag is set, it indicates that bitset is complemented. The `length` field encodes the number of bytes stored. `data` is a memory dump of `bitset!` series buffer, byte order is preserved. `data` field needs to be padded with enough NUL bytes to keep the next record aligned at 32-bit boundary.
 
-= TBD
-
 ==== `object!` anchor:object[] 
 
 ----
@@ -621,7 +623,7 @@ header/owner?=0|1
 header/reference?=0|1
 ----
 
-`on-set` and `arity` are optional.
+`class` field stores object's class ID. `on-set` field is a pair of 16-bit integers, each of which encodes an offset to `on-change*` and `on-deep-change*` function in object's values block. `arity` field has the same format as `on-set`, but encodes arities of the respective functions. These two fields are optional and are encoded only if `owner?` flags is set in record's header.
 
 ==== `typeset!` anchor:typeset[] 
 
@@ -632,6 +634,8 @@ Compact: TBD
 header/type=33
 ----
 
+`array1`, `array2` and `array3` fields form a a bitset where index of each `1` bit indicates a datatype ID contained inside a typeset.
+
 ==== `error!` anchor:error[] 
 
 ----
@@ -641,7 +645,7 @@ Compact: TBD
 header/type=34
 ----
 
-`arg1 arg2 arg3 near where stack`
+`code` field encodes error's identifier and is followed by 6 value records for error's fields: `arg1`, `arg2`, `arg3`, `near`, `where`, `stack`.
 
 ==== `vector!` anchor:vector[] 
 
@@ -654,7 +658,25 @@ header/type=35
 header/unit=1|2|4|8
 ----
 
-`unit` indicates the size of the vector element type size: 1, 2, 4 or 8 bytes. The `data` field holds the list of values. Needs to be padded with NUL bytes to align the next record to a 32-bit boundary (if `unit` is equal to 1 or 2).
+`type` field contain datatype ID of vector's element. `unit` field indicates the size of the vector element's type size in bytes. Only the following combinations of `type` and `unit` values are supported:
+
+.Combinations of `vector!` fields.
+[options="header" cols="1,1"]
+|===
+| Type | Unit 
+
+| `char!`, `integer!`
+| 1, 2, 4
+
+| `float!`
+| 4, 8
+
+| `percent!`
+| 8
+
+|===
+
+The `data` field holds the list of values. If `unit` is equal to 1 or 2, `data` needs to be padded with NUL bytes up to a 32-bit boundary.
 
 ==== `pair!` anchor:pair[] 
 
@@ -664,6 +686,8 @@ Compact: TBD
 
 header/type=37
 ----
+
+`x` and `y` fields encode the respective pair's elements as 32-bit integers.
 
 ==== `percent!` anchor:percent[] 
 
@@ -683,7 +707,10 @@ Default: header (4), array1 (4), array2 (4), array3 (4)
 Compact: TBD
 
 header/type=39
+header/unit=3-12
 ----
+
+`unit` field encodes tuple's size in bytes; only values from `3` to `12` are allowed. `array1`, `array2` and `array3` fields together form a memory dump of tuple's slot payload.
 
 ==== `map!` anchor:map[] 
 
@@ -696,7 +723,7 @@ header/type=40
 header/reference?=0|1
 ----
 
-The `length` field contains the number of elements (keys + values) to be stored in the map. The map elements simply follow the length definition, no separator or end delimiter is required.
+The `length` field contains the number of elements (both keys and values) encoded.
 
 ==== `binary!` anchor:binary[] 
 
@@ -708,6 +735,8 @@ Compact:  TBD
 header/type=41
 header/reference?=0|1
 ----
+
+`data` field contains memory dump of binary's series buffer, byte order is preserved.
 
 ==== `time!` anchor:time[] 
 
@@ -757,7 +786,13 @@ Compact: TBD
 header/type=47
 ----
 
-Date is packed into a 32-bit integer (same as in `red-date!`). Time value is stored as a 64-bit float.
+`date` field contains date value packed into a 32-bit integer. The following format is used (field sizes are in bits):
+
+----
+year (15), time? (1), month (4), day (5), timezone (7)
+----
+
+`year` and `timezone` sub-fields contain signed values. `time` field stores time value as a 64-bit float.
 
 ==== `money!` anchor:money[] 
 
@@ -769,7 +804,7 @@ header/type=49
 header/sign=0|1
 ----
 
-`amount` is a sequence of nibbles representing the money integral and decimal part (22 digits) in network byte order. If `sign` is set, the amount is interpreted as negative. `currency` is an integer value (0 for generic money, < 255 for existing currency code).
+`amount` field is a sequence of nibbles representing the base (17) and subunit (5) of money value, byte order is preserved. If `sign` flag is set, the amount is interpreted as negative. `currency` field is an integer value representing currency ID (0 for generic money, &le; 255 for existing currency code).
 
 ==== `ref!` anchor:ref[]
 
@@ -788,13 +823,15 @@ Same encoding rules as <<string, `string!`>>.
 ==== `image!` anchor:image[]
 
 ----
-Default:  header (4), head (4), length (4), rgba (4 * length)
+Default:  header (4), head (4), length (4), rgba (4 * width * height)
 Referral: header (4), head (4), buffer [reference]
 Compact:  TBD
 
 header/type=51
 header/reference?=0|1
 ----
+
+`length` field is a pair of 16-bit integers encoding width and height of an image. `rgba` field contains RGBA content of an image (4 bytes per pixel) with preserved byte order.
 
 == Redbin codec
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -12,60 +12,79 @@ The user interface for Redbin format access is provided via codec sub-system. Se
 
 The _default_ encoding format is optimized for decoding speed, while the _compact_ format requires a smaller storage space (at the expense of much slower decoding).
 
-Values are stored in little-endian format.
+NOTE: Specification of the compact encoding format is not yet defined.
 
-Lexical conventions:
+The general layout of Redbin data is described below. Each definition links to a respective section in this document.
 
-. _Numbers in parentheses indicate the byte size of the field._
+<<Header, Redbin header>>:: Holds information about the rest of the Redbin data.
+<<Symbol table, Symbol table>>:: Optional; if present, contains interned strings used by records of symbolic datatypes.
+<<Records definitions, Payload>>:: Stores Redbin records that encode Red values.
 
-. _Field names followed by a datatype name in a block are place-holders for a value of that datatype._
-
-. _Field names followed by equal sign have a fixed value._
-
+Data in these sections is stored in a little-endian format.
 
 == Header
 
-----
-magic="REDBIN" (6), version=1 (1), flags (1), length (4), size (4)
+Redbin data starts with a header having the following format:
 
-flags (option is enabled if bit is set):
-    bit0: compact mode
-    bit1: compressed
-    bit2: symbol table
-    bit3-7: <reserved>
+----
+magic="REDBIN" (6), version=1|2 (1), flags (1), length (4), size (4)
 
 length : number of root records to load.
 size   : size of records payload in bytes.
 ----
 
-If compression is applied, the data following the header is the payload to be compressed. Compression algorithm choice is implementation-dependent.
+Layout of `flags` field is described in the table below.
 
-== Symbol Table
+.Redbin header flags.
+[options="header" cols="1,9"]
+|===
+| Bits | Description 
 
-The symbol table immediately follows the header data. It is optional and should only be used if words are present in the rest of the Redbin payload. The symbol table has two sections:
+| 7-3
+| Reserved for future use.
 
-* a table of offsets to string representation of each symbol
-* strings buffers, NUL-terminated and concatenated to each other
+| 2
+| If set, indicates that Redbin data contains a <<Symbol table, symbol table>>.
 
-The position of a symbol in the table is its _index_ (zero-based), and it is used as reference for a symbol in contexts and words. The strings buffers section contains UTF-8 encoded strings with an optional padding at end to ensure 64-bit alignment. The offsets in the table are offsets in bytes from beginning of the strings buffers section to the referred string buffer.
+| 1
+| If set, indicates that data immidiately following `flags` field is compressed. Compression algorithm is implementation-dependent.
 
-Table encoding:
+| 0
+| If set, indicates that records section is encoded using the compact format.
 
- Default: length (4), size (4), offset1 (4), offset2 (4),...
- Compact: TBD
+|===
 
-`length` field contains the number of entries in the table. `size` field indicates the size of the string buffer in bytes (including optional tail padding bytes).
+Header is the only mandatory section in Redbin format encoding; both <<Symbol table, symbol table>> and <<Records definitions, payload>> can be ommitted, provided that relevant flags and fields a properly specified.
 
-During the decoding process, these symbols are merged within Red's own symbol table and the offsets are replaced by the symbol ID value from Red table. That is, the symbol references in the Redbin records are an indirect reference to Red's internal symbol table entries used only during the loading process.
+== Symbol table
 
-After the Symbol Table, Red values are stored as records in sequence with no special delimiter or end marker. The loaded values from root level are usually stored in a `block!` series.
+The symbol table immediately follows the header data. It is optional and should only be used if `any-word!` values are present in the <<Records definitions, Redbin payload>>. The symbol table has two sections:
+
+Offsets table:: A list of offsets to string representation of each symbol inside the strings buffer;
+
+Strings buffer:: Immidiately follows offsets table; contains UTF-8 encoded, NUL-terminated strings concatenated to each other, with an optional 64-bit boundary padding at the end of each string.
+
+The position of an offset in the table is its _index_ (zero-based), which is used as a reference by symbols in `context!` and  `any-word!` records. The offsets in the table are offsets in bytes from the beginning of the strings buffers section to the referred string.
+
+Table of offsets encoding is described below:
+
+----
+Default: length (4), size (4), offset (4) * length
+Compact: TBD
+----
+
+`length` field contains the number of entries in the table. `size` field indicates the size of the strings buffer in bytes (including optional padding).
+
+During the runtime booting process, these symbols are merged within Red's own symbol table and the offsets are replaced by the symbol ID values from that table. <<Redbin codec, Runtime codec>> omits this merging stage and instantiates symbols in-place for each relevant decoded record.
+
+After the symbol table, Red values are stored as a sequence of records, with no special delimiters or end markers. The loaded values from the root level are stored in a `block!` series.
 
 == Records definitions
 
-Each records starts with a 32-bit `header` field defined as:
+Each record in Redbin payload starts with a 32-bit `header` field defined as:
 
-.Header flags.
-[options="header" cols="1,3,2"]
+.Layout of Redbin record header.
+[options="header" cols="1,9,9"]
 |===
 | Bits | Description | Relevant datatypes
 
@@ -86,7 +105,7 @@ Each records starts with a 32-bit `header` field defined as:
 | `context!`
 
 | 27-26
-| Context type.
+| `kind` field; encodes `context!` type.
 | `context!`
 
 | 25
@@ -114,7 +133,7 @@ Each records starts with a 32-bit `header` field defined as:
 | `money!`
 
 | 19
-| Redbin record contains a reference __TBD link to section__.
+| `reference?` flag; if set, indicates that Redbin record contains a reference __TBD link to section__.
 | __TBD list datatypes__ `series!`, `any-function!`..?
 
 | 18-16
@@ -122,11 +141,11 @@ Each records starts with a 32-bit `header` field defined as:
 | --
 
 | 15-8
-| Unit type, encoded element size in a series buffer.
+| `unit` field; encodes element size (i.e. unit) in a series buffer.
 | `series!`
 
 | 7-0
-| Value type.
+| `type` field; encodes value type.
 | All.
 
 |===

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -283,6 +283,11 @@ Some Red value datatypes (listed below) are not supported by Redbin format.
 
 |===
 
+A list of additional limitations follows below:
+
+* Pre-compiled functions can be encoded, but on decoding start to behave as interpreted;
+* Object's `self` keyword cannot be encoded in some cases.
+
 === Datatypes
 
 This section describes the encoding of Redbin records that correspond to Red value datatypes.

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -150,20 +150,80 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 
 |===
 
-Here follows the description of each individual record:
+Here follows individual descriptions of each type of record.
 
-=== Padding anchor:padding[] 
+=== Special
+
+Some types of Redbin records do not correspond to any Red value datatype and are described in this section.
+
+==== Padding
 
 ----
 Default: header (4)
-Compact: n/a
+Compact: N/A
 
 header/type=0
 ----
 
-This empty type slot is used to properly align 64-bit values.
+This empty record is used to properly align 64-bit values.
 
-=== Datatype! anchor:datatype[] 
+==== Reference
+
+----
+Default: header (4), length (4), offset (4) * length
+Compact: TBD
+
+header/type=255
+----
+
+Reference records are used to encode various relations between Red values, such as `any-word!` bindings and shared `series!` buffers.
+
+`length` field specifies the number of `offset` fields contained inside a reference record; each `offset` field specifies a zero-based offset to an already loaded Red value thru its parent, starting from the root block. A list of such offsets effectively forms a path to a referenced value.
+
+Red value that is used as a parent to calculate offset into is called a _waypoint_; Red value to which the path is formed by a reference is called an _apex_. Reference records are usually used by other value records in order to obtain datatype-specific parts that they share with the apex. Red value record that contains a reference is called a _referral_. In all record definitions that follow, referral format is used to describe such form of encoding, which is used only when `reference?` header flag of a respective value record is set.
+
+Redbin records that can act as referrals are: `series!`, `map!`, `bitset!`, `any-word!`, `refinement!`, `object!`, `native!`, `action!`, `function!`.
+
+Only a selected number of datatypes can be a waypoint or an apex, and rules of offset calculation and referencing for each of them are described in the table below.
+
+.Datatypes thru which reference paths can be formed.
+[options="header" cols="1,2,2"]
+|===
+| Datatypes | Waypoint | Apex
+
+| `any-block!`, `map!`
+| An offset from the series' head. `map!` is treated as a linear block.
+| Buffer is reused.
+
+| `object!`
+| An offset from the head of the values block.
+| Binding information is reused.
+
+| `any-word!`, `refinement!`
+| An offset into a context to which value is bound, which is represented as either `object!` or `function!` value.
+| Binding information is reused.
+
+| `action!`, `native!`
+| Offset from the head of the spec block.
+| Spec buffer is reused.
+
+| `function!`
+| Offset of value `0` selects a spec block, offset of value `1` selects a body block. Other offset values are forbidden.
+| Binding information is reused.
+
+| `op!`
+| Offset of value `0` selects a spec block. Other offset values are forbidden.
+| Binding information of `function!` value from which `op!` is derived is reused.
+
+|===
+
+Referral can reference its own parent, in such case a cycle is formed.
+
+=== Datatypes
+
+This section describes the encoding of Redbin records that correspond to Red value datatypes.
+
+==== `datatype!` anchor:datatype[] 
 
 ----
 Default: header (4), value (4)

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -122,7 +122,7 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 | `context!`
 
 | 25
-| `set?` flag; if set, indicates that `any-word!` records is followed by value record to which decoded `any-word!` needs to be set. _TBD In current implementation this is disabled, and flag instead indicates that word is bound to a global context._
+| `set?` flag; if set, indicates that `any-word!` records is followed by value record to which decoded `any-word!` needs to be set.
 | `any-word!`
 
 | 24
@@ -146,8 +146,8 @@ Each record in Redbin payload starts with a 32-bit `header` field defined as:
 | `money!`
 
 | 19
-| `reference?` flag; if set, indicates that Redbin record contains a reference __TBD link to section__.
-| __TBD list datatypes__ `series!`, `any-function!`..?
+| `reference?` flag; if set, indicates that Redbin record contains a reference.
+| See <<Reference>> section.
 
 | 18-16
 | Reserved for future use.
@@ -234,13 +234,27 @@ Only a selected number of datatypes can be a waypoint or a target, and rules of 
 
 |===
 
-Referral can reference its own parent, in such case a cycle is formed.
+Referral can target its own parent, in such case a cycle is formed.
 
 === Unsupported
 
-NOTE: TBD.
+A number of Red value datatypes listed below are not supported by Redbin format.
 
-`routine!`, `ops!` derived from `routine!`, `handle!`, `event!`...
+.Red datatypes not supported by Redbin format.
+[options="header" cols="1,3"]
+|===
+| Datatypes | Reason
+
+| `routine!`, `op!` derived from `routine!`
+| Contains a direct pointer to machine code.
+
+| `handle!`
+| Contains a reference to session-specific and OS-specific system resource.
+
+| `event!`
+| Contains a direct pointer to session-specific and OS-specific system resource.
+
+|===
 
 === Datatypes
 
@@ -834,4 +848,6 @@ header/reference?=0|1
 
 == Redbin codec
 
-_TBD_
+NOTE: T.K.
+
+Interface, use-cases (on-disk serialization, sending programs over the wire ala RPC), `%.redbin` extension.

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -60,7 +60,7 @@ The general layout of Redbin data is described below. Each definition links to a
 <<Symbol table, Symbol table>>:: Optional; if present, contains interned strings used by records of symbolic datatypes.
 <<Records definitions, Payload>>:: Stores Redbin records that encode Red values.
 
-Data in these sections is stored in a little-endian format.
+Data in these sections is stored in a little-endian format. All integer fields represent non-negative values, but since Red runtime interprets them as signed, they have an upper limit of 2^31^-1.
 
 == Header
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -7,7 +7,34 @@ NOTE: Specification version 2.
 
 Redbin is a binary format that accurately represents Red values stored in memory while enabling fast loading (avoiding the parsing and validation stage of the text representation format). Redbin format is largely inspired by http://www.rebol.com/article/0044.html[REBin]; it can encode binding information for `any-word!` values, references to shared buffers for `series!` values, and can handle arbitrary cycles for `any-block!` values.
 
-The user interface for Redbin format access is provided via codec sub-system. See <<Redbin codec>> section for more details.
+== Redbin codec
+
+Redbin format enables use-cases typically associated with data serialization, such as:
+
+* Persistent state and image-based environments;
+* Remote procedure calls;
+* Sharing data and programs over the network with other systems;
+* Detecting changes in time-varying data.
+
+To make writing applications based on these ideas and methods possible, an interface to Redbin format is provided via the codec sub-system. Redbin codec can be accessed with `save` and `load` functions as described below.
+
+*Syntax*
+----
+save/as <where> <value> 'redbin
+save <file> <value>
+
+load/as <data> 'redbin
+load <file>
+
+<data>  : Redbin-encoded binary! value
+<value> : value of any supported datatype
+<where> : saving destination for encoded data; file!, url!, string!, binary!, none!
+<file>  : file! with .redbin extension
+----
+
+NOTE: Redbin codec cannot encode or decode <<Unsupported, unsupported>> values or, by extension, values that contain them.
+
+WARNING: Attempt to `load` Redbin data with malformed payload will likely lead to unexpected results or a runtime crash.
 
 == Lexical conventions
 

--- a/en/redbin.adoc
+++ b/en/redbin.adoc
@@ -848,6 +848,29 @@ header/reference?=0|1
 
 == Redbin codec
 
-NOTE: T.K.
+Redbin format enables use-cases typically associated with data serialization, such as:
 
-Interface, use-cases (on-disk serialization, sending programs over the wire ala RPC), `%.redbin` extension.
+* Persistent state and image-based environments;
+* Remote procedure calls;
+* Sharing data and programs over the network with other systems;
+* Detecting changes in time-varying data.
+
+To make these use-cases possible, an interface to Redbin format is provided via codec sub-system. Redbin codec can be acessed with `save` and `load` functions as described below.
+
+*Syntax*
+----
+save/as <where> <value> 'redbin
+save <file> <value>
+
+load/as <data> 'redbin
+load <file>
+
+<data>  : Redbin-encoded binary! value
+<value> : value of any supported datatype
+<where> : saving destination for encoded data; file!, url!, string!, binary!, none!
+<file>  : file! with .redbin extension
+----
+
+NOTE: Redbin codec cannot encode or decode <<Unsupported, unsupported>> values or values that contain them.
+
+WARNING: Attempt to `load` a Redbin data with malformed payload will likely lead to unexpected results or a runtime crash.


### PR DESCRIPTION
https://github.com/red/red/pull/4586 follow-up. Documents the new version of Redbin format and describes the Redbin codec interface. Description of an old format should probably be preserved for the time being, I can move it into a dedicated file if that's desired.