### PR TITLE
FEAT: remove `matrix-order` command.

### DIFF
--- a/cs/draw.adoc
+++ b/cs/draw.adoc
@@ -582,19 +582,6 @@ Hodnoty bloku jsou interně použity pro vytvoření následující transformač
 Při použití literálových slov (lit-words) `'pen` nebo `'fill-pen` se násobení aplikuje na aktuální pen nebo fill-pen.
 
 
-=== Matrix-order
-
-*Syntaxe*
-----
-matrix-order <mode>
-
-<mode> : 'append or 'prepend (word!).
-----
-
-*Popis*
-
-Definuje, zda nové matice v následných operacích jsou pre-multiplied (`prepend` - default mode) nebo post-multiplied (`append`) ke stávající matici.
-
 === Reset-matrix 
 
 *Syntaxe*

--- a/en/draw.adoc
+++ b/en/draw.adoc
@@ -613,20 +613,6 @@ The block values are used internally for building following transformation matri
 
 When the `'pen` or `'fill-pen` lit-words are used, the multiplication is applied respectively to the current pen or current fill-pen.
 
-=== Matrix-order
-
-*Syntax*
-
-----
-matrix-order <mode>
-
-<mode> : 'append or 'prepend (word!).
-----
-
-*Description*
-
-Defines if new matrices in subsequent matrix operations, are pre-multiplied (`prepend`, default mode) or post-multiplied (`append`) to the current matrix.
-
 === Reset-matrix 
 
 *Syntax*

--- a/fr/draw.adoc
+++ b/fr/draw.adoc
@@ -614,20 +614,6 @@ Les valeurs du bloc sont utilisées en interne pour construire la matrice de tra
 
 Lorsque les lit-words `'pen` ou `'fill-pen` sont utilisés, la multiplication est appliquée respectivement au trait courant ou au remplissage courant.
 
-=== Matrix-order (ordre des matrices)
-
-*Syntaxe*
-
-----
-matrix-order <mode>
-
-<mode> : 'append ou 'prepend (word!).
-----
-
-*Description*
-
-Définit si les nouvelles matrices dans les opérations matricielles subséquentes, sont pré-multipliées (`prepend`, mode par défaut) ou post-multipliées (`append`) avec la matrice courante.
-
 === Reset-matrix (réinitialise la matrice)
 
 *Syntaxe*

--- a/ja/draw.adoc
+++ b/ja/draw.adoc
@@ -546,18 +546,6 @@ matrix [a b c d e f]
 |0 0 1|
 ----
 
-=== Matrix-order
-
-.*構文*
-----
-matrix-order <mode>
-
-<mode> : 'append または 'prepend (word!)
-----
-*説明*
-
-後続の行列処理において、新しい行列が現在の行列に対して前方乗算（prepend）で処理されるか、後方乗算（append、デフォルトのモードです）で処理されるかを設定します。
-
 === Reset-matrix 
 
 *構文*

--- a/zh-hans/draw.adoc
+++ b/zh-hans/draw.adoc
@@ -659,21 +659,6 @@ matrix [a b c d e f]
 
 当 `'pen` 或 `'fill-pen` 原词被使用时，乘法分别会应用到当前画笔或当前填充笔上。
 
-=== `matrix-order`
-
-*语法*
-
-[source, red]
-----
-matrix-order <mode>
-
-<mode> : 'append 或 'prepend (word!)。
-----
-
-*描述*
-
-定义后续矩阵操作中的新矩阵是对当前矩阵前乘（`prepend`，默认模式）还是后乘（`append`）的。
-
 === `reset-matrix`
 
 *语法*


### PR DESCRIPTION
This feature is GDI+ specific, rarely used and not easy to be implemented on other platforms.