### PR TITLE
FIX: elaborate on CASE keyword.

### DIFF
--- a/en/parse.adoc
+++ b/en/parse.adoc
@@ -70,7 +70,7 @@ Parse offers a degree of flexibility by supporting different modes of operation.
 
 === Case-sensitivity
 
-By default, Parse follows Red semantics and is case-insensitive. Case-sensitivity can be enabled with `/case` refinement or turned on/off with `case` keyword.
+By default, Parse follows Red semantics and is case-insensitive. Case-sensitivity can be enabled with `/case` refinement and selectively turned on/off with `case` keyword. `case` changes comparison mode only for the rule that follows it and then restores it back, regardless of the rule's success or failure.
 
 *Syntax*
 


### PR DESCRIPTION
@rebolek noted that `case` works for the next rule only and then restores previous casing mode, while `/case` enables case-sensitivity globally.
```red
>> parse "Ab" [#"a" #"b"]
== true
>> parse "Ab" [case on #"a" #"b"]
== false
>> parse "Ab" [case on #"A" #"b"]
== true
>> parse/case "Ab" [case off #"a" #"b"]
== true
>> parse/case "Ab" [case off #"a" #"b"]
== true
>> parse/case "Ab" [case off #"a" #"B"]
== false
>> parse/case "Ab" [case off [#"a" #"B"]]
== true
```